### PR TITLE
Engine refactoring

### DIFF
--- a/org.emoflon.ibex.common/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.common/META-INF/MANIFEST.MF
@@ -8,11 +8,11 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: IBeXLanguage,
  IBeXLanguage.impl,
  IBeXLanguage.util,
+ org.emoflon.ibex.common.operational,
  org.emoflon.ibex.common.utils
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.emf.ecore.xmi,
- org.junit
+ org.eclipse.emf.ecore.xmi
 Bundle-ClassPath: .

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatch.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatch.java
@@ -1,0 +1,19 @@
+package org.emoflon.ibex.common.operational;
+
+import java.util.Collection;
+
+public interface IMatch {
+	Object get(String name);
+	
+	default void put(String name, Object o) {
+		throw new UnsupportedOperationException("This match does not support adding new mappings!");
+	}
+
+	Collection<String> parameterNames();
+
+	String patternName();
+
+	default boolean isInMatch(String name) {
+		return parameterNames().contains(name);
+	}
+}

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatch.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatch.java
@@ -2,18 +2,54 @@ package org.emoflon.ibex.common.operational;
 
 import java.util.Collection;
 
+/**
+ * An interface for matches for a pattern providing a mapping between parameter
+ * names and objects.
+ */
 public interface IMatch {
+	/**
+	 * Returns the object with the given name.
+	 * 
+	 * @param name
+	 *            the name to search for
+	 * @return the object
+	 */
 	Object get(String name);
-	
-	default void put(String name, Object o) {
+
+	/**
+	 * Adds the mapping for the given name to the given object.
+	 * 
+	 * @param name
+	 *            the name
+	 * @param object
+	 *            the object
+	 */
+	default void put(String name, Object object) {
 		throw new UnsupportedOperationException("This match does not support adding new mappings!");
 	}
 
-	Collection<String> parameterNames();
+	/**
+	 * Return all parameter names.
+	 * 
+	 * @return the parameter names
+	 */
+	Collection<String> getParameterNames();
 
-	String patternName();
+	/**
+	 * Returns the name of the pattern.
+	 * 
+	 * @return the name of the pattern
+	 */
+	String getPatternName();
 
+	/**
+	 * Returns whether there is a parameter with the given name in the match.
+	 * 
+	 * @param name
+	 *            the name of the paramete to search for
+	 * @return <code>true</code> if and only if such a parameter exists
+	 */
 	default boolean isInMatch(String name) {
-		return parameterNames().contains(name);
+		return getParameterNames().contains(name);
 	}
 }

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatchObserver.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatchObserver.java
@@ -1,0 +1,9 @@
+package org.emoflon.ibex.common.operational;
+
+public interface IMatchObserver {
+	public void addMatch(IMatch match);
+
+	public void removeMatch(IMatch match);
+
+	public boolean isPatternRelevantForCompiler(String patternName);
+}

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatchObserver.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IMatchObserver.java
@@ -1,9 +1,32 @@
 package org.emoflon.ibex.common.operational;
 
+/**
+ * Interface for getting notifications by the pattern matcher about new matches.
+ */
 public interface IMatchObserver {
+	/**
+	 * Notifies about a new match.
+	 * 
+	 * @param match
+	 *            the match
+	 */
 	public void addMatch(IMatch match);
 
+	/**
+	 * Notifies about a match which is not valid anymore.
+	 * 
+	 * @param match
+	 *            the match
+	 */
 	public void removeMatch(IMatch match);
 
+	/**
+	 * Checks whether the pattern with the given name is relevant for the observer.
+	 * 
+	 * @param patternName
+	 *            the name of the pattern
+	 * @return <code>true</code> if the pattern is relevant, <code>false</code>
+	 *         otherwise
+	 */
 	public boolean isPatternRelevantForCompiler(String patternName);
 }

--- a/org.emoflon.ibex.tgg.core.runtime/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.tgg.core.runtime/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.emoflon.ibex.tgg.editor,
- org.emoflon.ibex.tgg.ide
+ org.emoflon.ibex.tgg.ide,
+ org.emoflon.ibex.common
 Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/IBlackInterpreter.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/IBlackInterpreter.java
@@ -2,13 +2,13 @@ package org.emoflon.ibex.tgg.operational;
 
 import org.eclipse.emf.ecore.EPackage.Registry;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.ibex.common.operational.IMatchObserver;
 import org.emoflon.ibex.tgg.operational.defaults.IbexOptions;
-import org.emoflon.ibex.tgg.operational.strategies.OperationalStrategy;
 
 public interface IBlackInterpreter {
 	public ResourceSet createAndPrepareResourceSet(String workspacePath);
 	public void registerInternalMetamodels();
-	public void initialise(Registry registry, OperationalStrategy operationalStrategy, IbexOptions options);
+	public void initialise(Registry registry, IMatchObserver matchObserver, IbexOptions options);
 	
 	public void monitor(ResourceSet rs);
 	public void updateMatches();

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/csp/RuntimeTGGAttributeConstraintContainer.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/csp/RuntimeTGGAttributeConstraintContainer.java
@@ -31,7 +31,7 @@ public class RuntimeTGGAttributeConstraintContainer implements IRuntimeTGGAttrCo
 		
 	public RuntimeTGGAttributeConstraintContainer(List<TGGParamValue> variables, List<TGGAttributeConstraint> sortedConstraints, IMatch match, RuntimeTGGAttrConstraintProvider runtimeConstraintProvider) {
 		this.match = match;
-		this.boundObjectNames = match.parameterNames();
+		this.boundObjectNames = match.getParameterNames();
 		this.constraintProvider = runtimeConstraintProvider;
 		
 		extractRuntimeParameters(variables);

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/defaults/IbexGreenInterpreter.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/defaults/IbexGreenInterpreter.java
@@ -86,7 +86,7 @@ public class IbexGreenInterpreter implements IGreenInterpreter {
 	}
 
 	private void applyAttributeAssignments(IMatch match, TGGRuleNode node, EObject newObj) {
-		Collection<String> attributeNames = match.parameterNames().stream()
+		Collection<String> attributeNames = match.getParameterNames().stream()
 			.filter(pname -> { 
 				Optional<Pair<String, String>> o = IbexBasePattern.getNodeAndAttrFromVarName(pname);
 				Optional<Boolean> check = o.map(node_attr -> node_attr.getLeft().equals(node.getName()));

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/matches/IMatch.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/matches/IMatch.java
@@ -4,21 +4,7 @@ import java.util.Collection;
 
 import org.emoflon.ibex.tgg.operational.edge.RuntimeEdge;
 
-public interface IMatch {
-
-	Object get(String name);
-	
-	default void put(String name, Object o) {
-		throw new UnsupportedOperationException("This match does not support adding new mappings!");
-	}
-
-	Collection<String> parameterNames();
-
-	String patternName();
-
-	default boolean isInMatch(String name) {
-		return parameterNames().contains(name);
-	}
+public interface IMatch extends org.emoflon.ibex.common.operational.IMatch {
 
 	IMatch copy();
 

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/matches/MatchContainer.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/matches/MatchContainer.java
@@ -102,8 +102,8 @@ public class MatchContainer {
 	}
 
 	public String getRuleName(IMatch match) {
-		if (isFusedPatternMatch(match.patternName()))
-				return match.patternName();
+		if (isFusedPatternMatch(match.getPatternName()))
+				return match.getPatternName();
 		return idToRuleName.get(matchToRuleNameID.get(match));
 	}
 

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/matches/SimpleMatch.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/matches/SimpleMatch.java
@@ -26,12 +26,12 @@ public class SimpleMatch implements IMatch {
 	}
 
 	@Override
-	public Collection<String> parameterNames() {
+	public Collection<String> getParameterNames() {
 		return mappings.keySet();
 	}
 	
 	@Override
-	public String patternName() {
+	public String getPatternName() {
 		return patternName;
 	}
 

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/patterns/FusedGreenPattern.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/patterns/FusedGreenPattern.java
@@ -14,8 +14,8 @@ public abstract class FusedGreenPattern extends IbexGreenPattern {
 	}
 	
 	protected void createMarkers(String ruleName, IMatch match, Function<String, String> getName) {
-		String kernelName = MAUtil.getKernelName(match.patternName());
-		String complementName = MAUtil.getComplementName(match.patternName());
+		String kernelName = MAUtil.getKernelName(match.getPatternName());
+		String complementName = MAUtil.getComplementName(match.getPatternName());
 		
 		fusedFactory.getKernelFactory()
 			.create(getName.apply(kernelName))

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/patterns/IbexGreenPattern.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/patterns/IbexGreenPattern.java
@@ -86,7 +86,7 @@ public abstract class IbexGreenPattern implements IGreenPattern {
 		factory.getBlackSrcNodesInRule().forEach(n -> ra.getContextSrc().add((EObject) match.get(n.getName())));
 		factory.getBlackTrgNodesInRule().forEach(n -> ra.getContextTrg().add((EObject) match.get(n.getName())));
 		
-		match.parameterNames().stream()
+		match.getParameterNames().stream()
 			.filter(n -> !IbexBasePattern.isAttrNode(n))
 			.forEach(n -> ra.getNodeMappings().put(n, (EObject) match.get(n)));
 

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/OperationalStrategy.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/OperationalStrategy.java
@@ -113,12 +113,12 @@ public abstract class OperationalStrategy implements IMatchObserver {
 	
 	@Override
 	public void addMatch(org.emoflon.ibex.common.operational.IMatch match) {
-		this.addOperationalRuleMatch(PatternSuffixes.removeSuffix(match.patternName()), (IMatch) match);
+		this.addOperationalRuleMatch(PatternSuffixes.removeSuffix(match.getPatternName()), (IMatch) match);
 	}
 	
 	@Override
 	public void removeMatch(org.emoflon.ibex.common.operational.IMatch match) {
-		if (match.patternName().endsWith(PatternSuffixes.CONSISTENCY)) {
+		if (match.getPatternName().endsWith(PatternSuffixes.CONSISTENCY)) {
 			this.addBrokenMatch((IMatch) match);
 		}
 		this.removeOperationalRuleMatch((IMatch) match);
@@ -170,15 +170,15 @@ public abstract class OperationalStrategy implements IMatchObserver {
 		if (matchIsDomainConform(ruleName, match) && matchIsValidIsomorphism(ruleName, match)) {
 			operationalMatchContainer.addMatch(ruleName, match);
 			if (options.debug())
-				logger.debug("Received and added " + match.patternName());
+				logger.debug("Received and added " + match.getPatternName());
 		} else {
 			if (options.debug())
-				logger.debug("Received but rejected " + match.patternName());
+				logger.debug("Received but rejected " + match.getPatternName());
 		}
 	}
 
 	private boolean matchIsValidIsomorphism(String ruleName, IMatch match) {
-		if (match.patternName().endsWith(PatternSuffixes.CONSISTENCY)) {
+		if (match.getPatternName().endsWith(PatternSuffixes.CONSISTENCY)) {
 			// Make sure that node mappings comply to bindings in match
 			TGGRuleApplication ruleAppNode = (TGGRuleApplication) match
 					.get(ConsistencyPattern.getProtocolNodeName(ruleName));
@@ -333,17 +333,17 @@ public abstract class OperationalStrategy implements IMatchObserver {
 	}
 
 	protected Optional<IMatch> processOperationalRuleMatch(String ruleName, IMatch match) {
-		if (!isPatternRelevantForInterpreter(match.patternName())) {
+		if (!isPatternRelevantForInterpreter(match.getPatternName())) {
 			return Optional.empty();
 		}
 
 		IGreenPatternFactory factory = getGreenFactory(ruleName);
-		IGreenPattern greenPattern = factory.create(match.patternName());
+		IGreenPattern greenPattern = factory.create(match.getPatternName());
 		Optional<IMatch> comatch = greenInterpreter.apply(greenPattern, ruleName, match);
 
 		comatch.ifPresent(cm -> {
 			if (options.debug())
-				logger.debug("Successfully applied: " + match.patternName());
+				logger.debug("Successfully applied: " + match.getPatternName());
 			markedAndCreatedEdges.addAll(cm.getCreatedEdges());
 			greenPattern.getEdgesMarkedByPattern().forEach(e -> markedAndCreatedEdges.add(getRuntimeEdge(cm, e)));
 			createMarkers(greenPattern, cm, ruleName);
@@ -385,7 +385,7 @@ public abstract class OperationalStrategy implements IMatchObserver {
 
 			if (src == null | trg == null | ref == null)
 				throw new IllegalStateException(
-						"The match " + match.patternName() + " is invalid for this operational strategy (the edge -"
+						"The match " + match.getPatternName() + " is invalid for this operational strategy (the edge -"
 								+ ref.getName() + "-> appears to be expected but is missing)!  "
 								+ "Are you sure you have implemented isPatternRelevant correctly?");
 
@@ -400,7 +400,7 @@ public abstract class OperationalStrategy implements IMatchObserver {
 
 	public TGGRuleApplication getRuleApplicationNode(IMatch match) {
 		return (TGGRuleApplication) match
-				.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(match.patternName())));
+				.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(match.getPatternName())));
 	}
 
 	public void addBrokenMatch(IMatch match) {
@@ -534,6 +534,6 @@ public abstract class OperationalStrategy implements IMatchObserver {
 	}
 
 	public IGreenPattern revokes(IMatch match) {
-		throw new IllegalStateException("Not clear how to revoke a match of " + match.patternName());
+		throw new IllegalStateException("Not clear how to revoke a match of " + match.getPatternName());
 	}
 }

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/cc/CC.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/cc/CC.java
@@ -118,7 +118,7 @@ public abstract class CC extends OperationalStrategy {
 			return false;
 		
 		if(operationalMatchContainer.getMatches().stream()
-				.allMatch(m -> m.patternName().contains(PatternSuffixes.GENForCC))) {
+				.allMatch(m -> m.getPatternName().contains(PatternSuffixes.GENForCC))) {
 			//FIXME[Anjorin]:  Find an elegant way of properly discarding GENForCC matches!
 			return false;
 		}
@@ -162,13 +162,13 @@ public abstract class CC extends OperationalStrategy {
 		}
 		
 		//FIXME:[Milica] Check if this is really needed
-		TGGRuleApplication application = (TGGRuleApplication) comatch.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(comatch.patternName())));
+		TGGRuleApplication application = (TGGRuleApplication) comatch.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(comatch.getPatternName())));
 		application.setAmalgamated(true);
 	}
 	
 	//FIXME:[Milica] Check if maximality need to be done for edges as well
 	private void handleMaximality(IMatch match, Set<IMatch> contextRuleMatches, int kernelMatchID) {
-		String ruleName = removeAllSuffixes(match.patternName());
+		String ruleName = removeAllSuffixes(match.getPatternName());
 		TGGComplementRule rule = (TGGComplementRule) getRule(ruleName);
 		if(rule.isBounded()) {
 		//check if the complement rule was applied. If not, mark its kernel as invalid.
@@ -215,7 +215,7 @@ public abstract class CC extends OperationalStrategy {
 	}
 
 	private THashSet<EObject> getGenContextNodes(IMatch match){
-		THashSet<EObject> contextNodes = match.parameterNames().stream()
+		THashSet<EObject> contextNodes = match.getParameterNames().stream()
 				.map(n -> match.get(n)).collect(Collectors.toCollection(THashSet<EObject>::new));
 		return contextNodes;
 	}
@@ -225,14 +225,14 @@ public abstract class CC extends OperationalStrategy {
 	 */
 	private Set<IMatch> findAllComplementRuleContextMatches() {
 		Set<IMatch> allComplementRuleMatches = operationalMatchContainer.getMatches().stream()
-				.filter(m -> m.patternName().contains(PatternSuffixes.GENForCC))
+				.filter(m -> m.getPatternName().contains(PatternSuffixes.GENForCC))
 				.collect(Collectors.toSet());
 		return allComplementRuleMatches;
 	}
 	
 	private Set<IMatch> findAllComplementRuleMatches() {
 		Set<IMatch> allComplementRuleMatches = operationalMatchContainer.getMatches().stream()
-				.filter(m -> getComplementRulesNames().contains(PatternSuffixes.removeSuffix(m.patternName())))
+				.filter(m -> getComplementRulesNames().contains(PatternSuffixes.removeSuffix(m.getPatternName())))
 				.collect(Collectors.toSet());
 		return allComplementRuleMatches;
 	}

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/gen/MODELGEN.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/gen/MODELGEN.java
@@ -119,13 +119,13 @@ public abstract class MODELGEN extends OperationalStrategy {
 		}
 		
 		// Close the kernel, so other complement rules cannot find this match anymore
-		TGGRuleApplication application = (TGGRuleApplication) comatch.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(comatch.patternName())));
+		TGGRuleApplication application = (TGGRuleApplication) comatch.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(comatch.getPatternName())));
 		application.setAmalgamated(true);
 	}
 
 	private HashMap<String, Integer> callUpdatePolicy(Set<IMatch> complementRuleMatches) {
 		Set<String> uniqueRulesNames = complementRuleMatches.stream()
-				.map(m -> PatternSuffixes.removeSuffix(m.patternName()))
+				.map(m -> PatternSuffixes.removeSuffix(m.getPatternName()))
 				.distinct()
 				.collect(Collectors.toSet());
 		HashMap<String, Integer> complementRulesBounds = updatePolicy.getNumberOfApplications(uniqueRulesNames);
@@ -150,7 +150,7 @@ public abstract class MODELGEN extends OperationalStrategy {
 	
 	private Set<IMatch> findAllComplementRuleMatches() {
 		Set<IMatch> allComplementRuleMatches = operationalMatchContainer.getMatches().stream()
-				.filter(m -> getComplementRulesNames().contains(PatternSuffixes.removeSuffix(m.patternName())))
+				.filter(m -> getComplementRulesNames().contains(PatternSuffixes.removeSuffix(m.getPatternName())))
 				.collect(Collectors.toSet());
 
 		return allComplementRuleMatches;
@@ -209,7 +209,7 @@ public abstract class MODELGEN extends OperationalStrategy {
 	private void processBoundedRuleLimits(String name, HashMap<EReference, Integer> edgesToBeCreated) {
 		//find all matches for bounded rule collected by operational match container
 		int number = (int) findAllComplementRuleMatches().stream()
-				.filter(m -> m.patternName().contains(name)).count();
+				.filter(m -> m.getPatternName().contains(name)).count();
 		getRelevantEdges(((TGGComplementRule) getRule(name))).stream()
 		.forEach( e -> {edgesToBeCreated.put(e.getType(), number);});
 	}

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/sync/SYNC.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/sync/SYNC.java
@@ -93,7 +93,7 @@ public abstract class SYNC extends OperationalStrategy {
 	@Override
 	public IGreenPattern revokes(IMatch match) {
 		String ruleName = getRuleApplicationNode(match).getName();
-		return strategy.revokes(getGreenFactory(ruleName), match.patternName(), ruleName);
+		return strategy.revokes(getGreenFactory(ruleName), match.getPatternName(), ruleName);
 	}
 
 	@Override
@@ -136,9 +136,9 @@ public abstract class SYNC extends OperationalStrategy {
 		for (IMatch match : complementMatches) {
 			if (!isComplementMatchRelevant(match, comatch))
 				continue;
-			THashSet<EObject> fusedNodes = comatch.parameterNames().stream().map(n -> comatch.get(n))
+			THashSet<EObject> fusedNodes = comatch.getParameterNames().stream().map(n -> comatch.get(n))
 					.collect(Collectors.toCollection(THashSet<EObject>::new));
-			THashSet<EObject> complementNodes = match.parameterNames().stream().map(n -> match.get(n))
+			THashSet<EObject> complementNodes = match.getParameterNames().stream().map(n -> match.get(n))
 					.collect(Collectors.toCollection(THashSet<EObject>::new));
 
 			if (fusedNodes.containsAll(complementNodes))
@@ -152,8 +152,8 @@ public abstract class SYNC extends OperationalStrategy {
 	 * irrelevant complement matches
 	 */
 	private boolean isComplementMatchRelevant(IMatch match, IMatch comatch) {
-		if (!match.patternName().contains(PatternSuffixes.removeSuffix(match.patternName()))
-				|| !isPatternRelevantForInterpreter(match.patternName()))
+		if (!match.getPatternName().contains(PatternSuffixes.removeSuffix(match.getPatternName()))
+				|| !isPatternRelevantForInterpreter(match.getPatternName()))
 			return false;
 		return true;
 	}
@@ -168,7 +168,7 @@ public abstract class SYNC extends OperationalStrategy {
 		} else {
 			// if it is a kernel or a complement rule
 			protocolNode = (TGGRuleApplication) comatch
-					.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(comatch.patternName())));
+					.get(ConsistencyPattern.getProtocolNodeName(PatternSuffixes.removeSuffix(comatch.getPatternName())));
 		}
 
 		if (isComplementMatch(ruleName)) {
@@ -199,7 +199,7 @@ public abstract class SYNC extends OperationalStrategy {
 	}
 
 	private boolean isComplementRuleApplicable(IMatch match, String ruleName) {
-		if (!isPatternRelevantForInterpreter(match.patternName())) {
+		if (!isPatternRelevantForInterpreter(match.getPatternName())) {
 			return false;
 		}
 
@@ -220,7 +220,7 @@ public abstract class SYNC extends OperationalStrategy {
 	}
 
 	private THashSet<EObject> getContextNodesWithoutProtocolNode(IMatch match) {
-		THashSet<EObject> contextNodes = match.parameterNames().stream()
+		THashSet<EObject> contextNodes = match.getParameterNames().stream()
 				.filter(n -> !(match.get(n) instanceof TGGRuleApplication)).map(n -> match.get(n))
 				.collect(Collectors.toCollection(THashSet<EObject>::new));
 		return contextNodes;
@@ -228,7 +228,7 @@ public abstract class SYNC extends OperationalStrategy {
 
 	private Set<IMatch> findAllComplementRuleMatches() {
 		Set<IMatch> allComplementRuleMatches = operationalMatchContainer.getMatches().stream()
-				.filter(m -> getComplementRulesNames().contains(PatternSuffixes.removeSuffix(m.patternName())))
+				.filter(m -> getComplementRulesNames().contains(PatternSuffixes.removeSuffix(m.getPatternName())))
 				.collect(Collectors.toSet());
 
 		return allComplementRuleMatches;


### PR DESCRIPTION
- Adds common interfaces `IMatch` and `IMatchObserver`.
- Refactor TGG code to use those interfaces: `OperationalStrategy implements IMatchObserver`, TGG's `IMatch extends IMatch extends org.emoflon.ibex.common.operational.IMatch`.