### PR TITLE
Creation and deletion of nodes and references

### DIFF
--- a/org.emoflon.ibex.common/model/Common.ecore
+++ b/org.emoflon.ibex.common/model/Common.ecore
@@ -5,6 +5,28 @@
   <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
     <details key="documentation" value="Model for IBeXPatterns."/>
   </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="IBeXCreatePattern" eSuperTypes="#//IBeXNamedElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="A pattern for creation defines which nodes and edges are created. Nodes which are not created, but source or target node of a created edge are context nodes."/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="contextNodes" upperBound="-1"
+        eType="#//IBeXNode" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="createdEdges" upperBound="-1"
+        eType="#//IBeXEdge" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="createdNodes" upperBound="-1"
+        eType="#//IBeXNode" containment="true"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="IBeXDeletePattern" eSuperTypes="#//IBeXNamedElement">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="A pattern for deletion defines which nodes and edges are deleted. Nodes which are not deleted, but source or target node of a deleted edge are context nodes."/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="contextNodes" upperBound="-1"
+        eType="#//IBeXNode" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="deletedEdges" upperBound="-1"
+        eType="#//IBeXEdge" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="deletedNodes" upperBound="-1"
+        eType="#//IBeXNode" containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="IBeXEdge">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="A typed edge connects two nodes. "/>
@@ -15,13 +37,13 @@
         eOpposite="#//IBeXNode/incomingEdges"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EReference"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="IBexNamedElement">
+  <eClassifiers xsi:type="ecore:EClass" name="IBeXNamedElement" abstract="true">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="Any IBeX element which has a name should inherit form this class."/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="IBeXNode" eSuperTypes="#//IBexNamedElement">
+  <eClassifiers xsi:type="ecore:EClass" name="IBeXNode" eSuperTypes="#//IBeXNamedElement">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="A typed node can reference other nodes via edges."/>
     </eAnnotations>
@@ -45,7 +67,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="key" eType="#//IBeXNode"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="#//IBeXNode"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="IBeXPattern" eSuperTypes="#//IBexNamedElement">
+  <eClassifiers xsi:type="ecore:EClass" name="IBeXPattern" eSuperTypes="#//IBeXNamedElement">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="A pattern consists of local edges and nodes, signature nodes. It can invoke other patterns and force nodes be different."/>
     </eAnnotations>
@@ -75,6 +97,10 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="A set of IBeXPatterns. Each pattern in a set must have an unique name."/>
     </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="createPatterns" upperBound="-1"
+        eType="#//IBeXCreatePattern" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="deletePatterns" upperBound="-1"
+        eType="#//IBeXDeletePattern" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="patterns" upperBound="-1"
         eType="#//IBeXPattern" containment="true"/>
   </eClassifiers>

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IContextPatternInterpreter.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IContextPatternInterpreter.java
@@ -8,7 +8,7 @@ import IBeXLanguage.IBeXPatternSet;
 /**
  * Interface for a pattern matcher.
  */
-public interface IPatternInterpreter {
+public interface IContextPatternInterpreter {
 	/**
 	 * Initializes the patterns of the engine with the given IBeXPatterns, which
 	 * need to be transformed into the patterns of the concrete pattern matcher.

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/ICreatePatternInterpreter.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/ICreatePatternInterpreter.java
@@ -1,0 +1,21 @@
+package org.emoflon.ibex.common.operational;
+
+import java.util.Optional;
+
+import IBeXLanguage.IBeXCreatePattern;
+
+/**
+ * The interface for the interpreter which applies an {@link IBeXCreatePattern}.
+ */
+public interface ICreatePatternInterpreter {
+	/**
+	 * Applies the given creations of the pattern on the given match.
+	 * 
+	 * @param createPattern
+	 *            the pattern defining which elements are created
+	 * @param match
+	 *            the match
+	 * @return the co-match
+	 */
+	Optional<IMatch> apply(IBeXCreatePattern createPattern, IMatch match);
+}

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IDeletePatternInterpreter.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/operational/IDeletePatternInterpreter.java
@@ -1,0 +1,21 @@
+package org.emoflon.ibex.common.operational;
+
+import java.util.Optional;
+
+import IBeXLanguage.IBeXDeletePattern;
+
+/**
+ * The interface for the interpreter which applies an {@link IBeXDeletePattern}.
+ */
+public interface IDeletePatternInterpreter {
+	/**
+	 * Applies the deletions of the pattern on the given match.
+	 * 
+	 * @param deletePattern
+	 *            the pattern defining which elements are deleted
+	 * @param match
+	 *            the match
+	 * @return the match after the pattern application
+	 */
+	Optional<IMatch> apply(IBeXDeletePattern deletePattern, IMatch match);
+}

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFManipulationUtils.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFManipulationUtils.java
@@ -1,4 +1,6 @@
-package org.emoflon.ibex.gt.utils;
+package org.emoflon.ibex.common.utils;
+
+import java.util.Optional;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -18,6 +20,18 @@ public class EMFManipulationUtils {
 	 */
 	public static boolean isDanglingNode(final EObject eObject) {
 		return eObject.eResource() == null;
+	}
+
+	/**
+	 * Checks whether the given object is a dangling node.
+	 * 
+	 * @param eObject
+	 *            an {@link Optional} for a node
+	 * @return true if the node is a dangling node; false if the node is not a
+	 *         dangling node or the Optional is not present
+	 */
+	public static boolean isDanglingNode(Optional<EObject> eObject) {
+		return eObject.map(EMFManipulationUtils::isDanglingNode).orElse(false);
 	}
 
 	/**

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/IBeXPatternUtils.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/IBeXPatternUtils.java
@@ -1,0 +1,79 @@
+package org.emoflon.ibex.common.utils;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import IBeXLanguage.IBeXNode;
+import IBeXLanguage.IBeXPattern;
+import IBeXLanguage.IBeXPatternSet;
+
+/**
+ * Utility for working with {@link IBeXPatternSet}.
+ */
+public class IBeXPatternUtils {
+
+	/**
+	 * Checks whether the given pattern is empty.
+	 * 
+	 * @param ibexPattern
+	 *            the pattern
+	 * @return true if the pattern contains no nodes
+	 */
+	public static boolean isEmptyPattern(final IBeXPattern ibexPattern) {
+		return ibexPattern.getSignatureNodes().isEmpty() && ibexPattern.getLocalNodes().isEmpty();
+	}
+
+	/**
+	 * Finds an {@link IBeXNode} with the given name in the given IBeXPattern.
+	 * 
+	 * @param ibexPattern
+	 *            the IBeXPattern, must not be <code>null</code>
+	 * @param name
+	 *            the name to search for, must not be <code>null</code>
+	 * @return an Optional for a local IBeXNode
+	 */
+	public static Optional<IBeXNode> findIBeXNodeWithName(final IBeXPattern ibexPattern, final String name) {
+		Objects.requireNonNull(ibexPattern, "pattern must not be null!");
+		Objects.requireNonNull(name, "name must not be null!");
+		return findIBeXNodeWithName(ibexPattern.getLocalNodes(), ibexPattern.getSignatureNodes(), name);
+	}
+
+	/**
+	 * Searches for an {@link IBeXNode} with the given name in the given list of
+	 * nodes.
+	 * 
+	 * @param nodes
+	 *            the nodes
+	 * @param name
+	 *            the name to search for
+	 * @return an {@link Optional} for a node with the given name
+	 */
+	public static Optional<IBeXNode> findIBeXNodeWithName(final List<IBeXNode> nodes, final String name) {
+		Objects.requireNonNull(nodes, "nodes must not be null!");
+		Objects.requireNonNull(name, "name must not be null!");
+		return nodes.stream().filter(node -> name.equals(node.getName())).findAny();
+	}
+
+	/**
+	 * Searches for an {@link IBeXNode} with the given name in the given lists of
+	 * nodes.
+	 * 
+	 * @param nodes
+	 *            the nodes
+	 * @param nodes2
+	 *            more nodes
+	 * @param name
+	 *            the name to search for
+	 * @return an {@link Optional} for a node with the given name
+	 */
+	public static Optional<IBeXNode> findIBeXNodeWithName(final List<IBeXNode> nodes, final List<IBeXNode> nodes2,
+			final String name) {
+		Optional<IBeXNode> node = findIBeXNodeWithName(nodes, name);
+		if (node.isPresent()) {
+			return node;
+		} else {
+			return findIBeXNodeWithName(nodes2, name);
+		}
+	}
+}

--- a/org.emoflon.ibex.gt/model/Gt.ecore
+++ b/org.emoflon.ibex.gt/model/Gt.ecore
@@ -61,6 +61,8 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="Rules consists of a graph with typed nodes and edges."/>
     </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="abstract" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="executable" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="graph" eType="#//GTGraph"
         containment="true"/>
   </eClassifiers>

--- a/org.emoflon.ibex.gt/model/Gt.ecore
+++ b/org.emoflon.ibex.gt/model/Gt.ecore
@@ -5,6 +5,14 @@
   <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
     <details key="documentation" value="Internal model for graph transformation rules."/>
   </eAnnotations>
+  <eClassifiers xsi:type="ecore:EEnum" name="GTBindingType">
+    <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
+      <details key="documentation" value="The binding type defines whether a graph element is context, created or deleted."/>
+    </eAnnotations>
+    <eLiterals name="CONTEXT"/>
+    <eLiterals name="CREATE" value="1" literal="CREATE"/>
+    <eLiterals name="DELETE" value="2" literal="DELETE"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GTEdge" eSuperTypes="#//GTGraphElement">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="A typed edge connects two nodes."/>
@@ -26,8 +34,10 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GTGraphElement" eSuperTypes="#//GTNamedElement">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
-      <details key="documentation" value="Any element in the internal GT model which is contained in a graph should inherit from this class."/>
+      <details key="documentation" value="Any element in the internal GT model which is contained in a graph should inherit from this class. A graph element must be of one of the binding types CONTEXT, CREATE or DELETE."/>
     </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="bindingType" lowerBound="1"
+        eType="#//GTBindingType"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="GTNamedElement">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
@@ -44,4 +44,11 @@ public abstract class GraphTransformationAPI {
 	public void updateMatches() {
 		this.interpreter.updateMatches();
 	}
+
+	/**
+	 * Saves the model.
+	 */
+	public void save() {
+		this.interpreter.save();
+	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
@@ -1,15 +1,20 @@
 package org.emoflon.ibex.gt.api;
 
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.emoflon.ibex.common.operational.IContextPatternInterpreter;
 import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
 
 /**
  * This abstract API is the super class for all concrete APIs generated for a
- * set of models.
+ * set of model resources.
  * 
- * Concrete Implementations must implement loading rules from .gt files into the
- * engine.
+ * The concrete implementation provide methods to perform queries and rule
+ * applications on the given resource set which must not be empty.
+ * 
+ * All elements created during rule applications are added to the default
+ * resource. The default resource can be explicitly set in the constructor,
+ * otherwise the first resource in the resource set will be used.
  */
 public abstract class GraphTransformationAPI {
 	/**
@@ -23,10 +28,25 @@ public abstract class GraphTransformationAPI {
 	 * @param engine
 	 *            the engine to use for queries and transformations
 	 * @param model
-	 *            the resource set containing the model file
+	 *            the resource set containing at least one model resource
 	 */
 	public GraphTransformationAPI(final IContextPatternInterpreter engine, final ResourceSet model) {
 		this.interpreter = new GraphTransformationInterpreter(engine, model);
+	}
+
+	/**
+	 * Creates a new GraphTransformationAPI for given engine and resource set.
+	 * 
+	 * @param engine
+	 *            the engine to use for queries and transformations
+	 * @param model
+	 *            the resource set containing at least one model resource
+	 * @param defaultResource
+	 *            the default resource
+	 */
+	public GraphTransformationAPI(final IContextPatternInterpreter engine, final ResourceSet model,
+			final Resource defaultResource) {
+		this.interpreter = new GraphTransformationInterpreter(engine, model, defaultResource);
 	}
 
 	/**
@@ -43,12 +63,5 @@ public abstract class GraphTransformationAPI {
 	 */
 	public void updateMatches() {
 		this.interpreter.updateMatches();
-	}
-
-	/**
-	 * Saves the model.
-	 */
-	public void save() {
-		this.interpreter.save();
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
@@ -1,7 +1,7 @@
 package org.emoflon.ibex.gt.api;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.emoflon.ibex.common.operational.IPatternInterpreter;
+import org.emoflon.ibex.common.operational.IContextPatternInterpreter;
 import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
 
 /**
@@ -25,7 +25,7 @@ public abstract class GraphTransformationAPI {
 	 * @param model
 	 *            the resource set containing the model file
 	 */
-	public GraphTransformationAPI(final IPatternInterpreter engine, final ResourceSet model) {
+	public GraphTransformationAPI(final IContextPatternInterpreter engine, final ResourceSet model) {
 		this.interpreter = new GraphTransformationInterpreter(engine, model);
 	}
 

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationApplicableRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationApplicableRule.java
@@ -1,0 +1,55 @@
+package org.emoflon.ibex.gt.api;
+
+import java.util.Optional;
+
+import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
+
+/**
+ * This is the abstraction for all applicable rules.
+ * 
+ * Concrete Implementations must have a constructor to set the parameters
+ * required for rule application and getters for all parameters.
+ * 
+ * @param <M>
+ *            the type of matches returned by this rule
+ * @param <R>
+ *            the own type
+ */
+public abstract class GraphTransformationApplicableRule<M extends GraphTransformationMatch<M, R>, R extends GraphTransformationRule<M, R>>
+		extends GraphTransformationRule<M, R> {
+
+	/**
+	 * Creates a new executable rule.
+	 * 
+	 * @param interpreter
+	 *            the interpreter
+	 * @param ruleName
+	 *            the name of the rule
+	 */
+	public GraphTransformationApplicableRule(GraphTransformationInterpreter interpreter, String ruleName) {
+		super(interpreter, ruleName);
+	}
+
+	/**
+	 * Executes the rule on the given match.
+	 * 
+	 * @return an {@link Optional} for the the co-match after rule application
+	 */
+	public final Optional<M> apply(final M match) {
+		return this.interpreter.execute(match.toIMatch()).map(m -> this.convertMatch(m));
+	}
+
+	/**
+	 * Executes the rule on an arbitrary match if there is a match.
+	 * 
+	 * @return an {@link Optional} for the the co-match after rule application
+	 */
+	public final Optional<M> apply() {
+		Optional<M> match = this.findAnyMatch();
+		if (!match.isPresent()) {
+			return Optional.empty();
+		}
+		return this.apply(match.get());
+	}
+
+}

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
@@ -59,31 +59,24 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 
 	/**
 	 * Executes the rule on the given match.
+	 * 
+	 * @return an {@link Optional} for the the co-match after rule application
 	 */
-	public final void execute(final M match) {
-		this.interpreter.execute(ruleName, match.toIMatch());
+	public final Optional<M> execute(final M match) {
+		return this.interpreter.execute(match.toIMatch()).map(m -> this.convertMatch(m));
 	}
 
 	/**
-	 * Executes the rule on an arbitrary match.
+	 * Executes the rule on an arbitrary match if there is a match.
 	 * 
-	 * @return an {@link Optional} for the match the rule was executed on
+	 * @return an {@link Optional} for the the co-match after rule application
 	 */
 	public final Optional<M> execute() {
-		Optional<M> anyMatch = this.findAnyMatch();
-		anyMatch.ifPresent(match -> this.execute(match));
-		return anyMatch;
-	}
-
-	/**
-	 * Executes the rule on all matches.
-	 * 
-	 * @return the list of matches the rule was executed on
-	 */
-	public final Collection<M> executeAll() {
-		Collection<M> matches = this.findMatches();
-		matches.forEach(match -> this.execute(match));
-		return matches;
+		Optional<M> match = this.findAnyMatch();
+		if (!match.isPresent()) {
+			return Optional.empty();
+		}
+		return this.execute(match.get());
 	}
 
 	/**

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
@@ -14,7 +14,7 @@ import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
  * This is the abstraction for all rules.
  * 
  * Concrete Implementations must have a constructor to set the parameters
- * required for rule application and getters for all parameters.
+ * required for finding matches and getters for all parameters.
  * 
  * @param <M>
  *            the type of matches returned by this rule
@@ -42,6 +42,8 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	 * 
 	 * @param interpreter
 	 *            the interpreter
+	 * @param ruleName
+	 *            the name of the rule
 	 */
 	public GraphTransformationRule(final GraphTransformationInterpreter interpreter, final String ruleName) {
 		this.interpreter = interpreter;
@@ -55,28 +57,6 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	 */
 	protected final String getRuleName() {
 		return this.ruleName;
-	}
-
-	/**
-	 * Executes the rule on the given match.
-	 * 
-	 * @return an {@link Optional} for the the co-match after rule application
-	 */
-	public final Optional<M> execute(final M match) {
-		return this.interpreter.execute(match.toIMatch()).map(m -> this.convertMatch(m));
-	}
-
-	/**
-	 * Executes the rule on an arbitrary match if there is a match.
-	 * 
-	 * @return an {@link Optional} for the the co-match after rule application
-	 */
-	public final Optional<M> execute() {
-		Optional<M> match = this.findAnyMatch();
-		if (!match.isPresent()) {
-			return Optional.empty();
-		}
-		return this.execute(match.get());
 	}
 
 	/**

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
@@ -119,7 +119,8 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	}
 
 	/**
-	 * Unsubscribes notifications of all new matches for the given {@link Consumer}.
+	 * Deletes the subscription of notifications of all new matches for the given
+	 * {@link Consumer}.
 	 * 
 	 * @param action
 	 *            the {@link Consumer}
@@ -143,8 +144,8 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	}
 
 	/**
-	 * Unsubscribes notifications of all disappearing matches for the given
-	 * {@link Consumer}.
+	 * Deletes the subscription of notifications of all disappearing matches for the
+	 * given {@link Consumer}.
 	 * 
 	 * @param action
 	 *            the {@link Consumer}
@@ -165,8 +166,20 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	 * @param action
 	 *            the {@link Consumer} to notify
 	 */
-	public final void whenMatchDisappears(final M match, final Consumer<M> action) {
+	public final void subscribeMatchDisappears(final M match, final Consumer<M> action) {
 		this.interpreter.subscribeMatchDisappears(match.toIMatch(), this.convertConsumer(action));
+	}
+
+	/**
+	 * Deletes the subscription of a notification when the given match disappears.
+	 * 
+	 * @param match
+	 *            the match to observe
+	 * @param action
+	 *            the {@link Consumer} to notify
+	 */
+	public final void unsubscribeMatchDisappears(final M match, final Consumer<M> action) {
+		this.interpreter.unsubscribeMatchDisappears(match.toIMatch(), this.convertConsumer(action));
 	}
 
 	/**

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/generator/GTPackageBuilder.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/generator/GTPackageBuilder.java
@@ -252,10 +252,12 @@ public class GTPackageBuilder implements GTBuilderExtension {
 	private void generateAPI() {
 		IFolder matchesPackage = this.ensureFolderExists(this.apiPackage.getFolder("matches"));
 		IFolder rulesPackage = this.ensureFolderExists(this.apiPackage.getFolder("rules"));
-		this.gtRuleSet.getRules().forEach(gtRule -> {
-			this.fileGenerator.generateMatchJavaFile(matchesPackage, gtRule);
-			this.fileGenerator.generateRuleJavaFile(rulesPackage, gtRule);
-		});
+		this.gtRuleSet.getRules().stream() //
+				.filter(gtRule -> !gtRule.isAbstract()) // ignore abstract rules
+				.forEach(gtRule -> {
+					this.fileGenerator.generateMatchJavaFile(matchesPackage, gtRule);
+					this.fileGenerator.generateRuleJavaFile(rulesPackage, gtRule);
+				});
 
 		String patternPath = this.project.getName() + "/src-gen/" + this.path.toString() + "/api/ibex-patterns.xmi";
 		this.fileGenerator.generateAPIJavaFile(this.apiPackage, patternPath);

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/generator/JavaFileGenerator.xtend
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/generator/JavaFileGenerator.xtend
@@ -235,9 +235,10 @@ class JavaFileGenerator {
 	 * Generates the Java Rule class for the given rule.
 	 */
 	public def generateRuleJavaFile(IFolder rulesPackage, GTRule rule) {
+		val ruleType = if(rule.executable) 'GraphTransformationApplicableRule' else 'GraphTransformationRule';
 		val imports = newHashSet(
 			'org.emoflon.ibex.common.operational.IMatch',
-			'org.emoflon.ibex.gt.api.GraphTransformationRule',
+			'''org.emoflon.ibex.gt.api.«ruleType»''',
 			'org.emoflon.ibex.gt.engine.GraphTransformationInterpreter',
 			'''«this.packageName».api.matches.«getMatchClassName(rule)»'''
 		)
@@ -250,7 +251,7 @@ class JavaFileGenerator {
 			/**
 			 * The rule «rule.name»().
 			 */
-			public class «getRuleClassName(rule)» extends GraphTransformationRule<«getMatchClassName(rule)», «getRuleClassName(rule)»> {
+			public class «getRuleClassName(rule)» extends «ruleType»<«getMatchClassName(rule)», «getRuleClassName(rule)»> {
 				private static String ruleName = "«rule.name»";
 			
 				/**

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/generator/JavaFileGenerator.xtend
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/generator/JavaFileGenerator.xtend
@@ -108,7 +108,7 @@ class JavaFileGenerator {
 		val imports = newHashSet(
 			'org.eclipse.emf.common.util.URI',
 			'org.eclipse.emf.ecore.resource.ResourceSet',
-			'org.emoflon.ibex.common.operational.IPatternInterpreter',
+			'org.emoflon.ibex.common.operational.IContextPatternInterpreter',
 			'org.emoflon.ibex.gt.api.GraphTransformationAPI'
 		)
 		this.gtRuleSet.rules.forall [
@@ -137,7 +137,7 @@ class JavaFileGenerator {
 				 * @param model
 				 *            the resource set containing the model file
 				 */
-				public «apiClassName»(final IPatternInterpreter engine, final ResourceSet model) {
+				public «apiClassName»(final IContextPatternInterpreter engine, final ResourceSet model) {
 					super(engine, model);
 					URI uri = URI.createURI("../" + patternPath);
 					this.interpreter.loadPatternSet(uri);
@@ -156,7 +156,7 @@ class JavaFileGenerator {
 				 * @param workspacePath
 				 *            the path to the workspace
 				 */
-				public «apiClassName»(final IPatternInterpreter engine, final ResourceSet model,
+				public «apiClassName»(final IContextPatternInterpreter engine, final ResourceSet model,
 						final String workspacePath) {
 					super(engine, model);
 					URI uri = URI.createURI(workspacePath + patternPath);

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
@@ -7,7 +7,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emoflon.ibex.common.operational.ICreatePatternInterpreter;
 import org.emoflon.ibex.common.operational.IMatch;
-import org.emoflon.ibex.gt.utils.EMFManipulationUtils;
+import org.emoflon.ibex.common.utils.EMFManipulationUtils;
 
 import IBeXLanguage.IBeXCreatePattern;
 

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
@@ -1,0 +1,55 @@
+package org.emoflon.ibex.gt.engine;
+
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.emoflon.ibex.common.operational.ICreatePatternInterpreter;
+import org.emoflon.ibex.common.operational.IMatch;
+
+import IBeXLanguage.IBeXCreatePattern;
+import IBeXLanguage.IBeXEdge;
+import IBeXLanguage.IBeXNode;
+
+/**
+ * Interpreter applying creation of elements for graph transformation.
+ */
+public class GraphTransformationCreateInterpreter implements ICreatePatternInterpreter {
+	private Resource resource;
+
+	public GraphTransformationCreateInterpreter(final Resource resource) {
+		this.resource = resource;
+	}
+
+	@Override
+	public Optional<IMatch> apply(final IBeXCreatePattern createPattern, final IMatch match) {
+		createPattern.getCreatedNodes().forEach(node -> this.createNode(node, match));
+		//createPattern.getCreatedEdges().forEach(edge -> this.createEdge(edge, match));
+		return Optional.of(match);
+	}
+
+	private void createNode(IBeXNode node, final IMatch match) {
+		EObject newNode = EcoreUtil.create(node.getType());
+		this.resource.getContents().add(newNode);
+		match.put(node.getName(), newNode);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private void createEdge(IBeXEdge edge, final IMatch match) {
+		System.out.println(edge.getSourceNode().getName() + " : " + match.get(edge.getSourceNode().getName()));
+		EObject src = (EObject) match.get(edge.getSourceNode().getName());
+		EObject trg = (EObject) match.get(edge.getSourceNode().getName());
+
+		System.out.println("Create edge " + edge.getType().getName() + " - " + src + " - " + trg);
+
+		EReference reference = edge.getType();
+		if (reference.isMany()) {
+			((EList) src.eGet(reference)).add(trg);
+		} else {
+			src.eSet(reference, trg);
+		}
+	}
+}

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
@@ -2,17 +2,14 @@ package org.emoflon.ibex.gt.engine;
 
 import java.util.Optional;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emoflon.ibex.common.operational.ICreatePatternInterpreter;
 import org.emoflon.ibex.common.operational.IMatch;
+import org.emoflon.ibex.gt.utils.EMFManipulationUtils;
 
 import IBeXLanguage.IBeXCreatePattern;
-import IBeXLanguage.IBeXEdge;
-import IBeXLanguage.IBeXNode;
 
 /**
  * Interpreter applying creation of elements for graph transformation.
@@ -32,43 +29,16 @@ public class GraphTransformationCreateInterpreter implements ICreatePatternInter
 
 	@Override
 	public Optional<IMatch> apply(final IBeXCreatePattern createPattern, final IMatch match) {
-		createPattern.getCreatedNodes().forEach(node -> this.createNode(node, match));
-		createPattern.getCreatedEdges().forEach(edge -> this.createEdge(edge, match));
+		createPattern.getCreatedNodes().forEach(node -> {
+			EObject newNode = EcoreUtil.create(node.getType());
+			this.defaultResource.getContents().add(newNode);
+			match.put(node.getName(), newNode);
+		});
+		createPattern.getCreatedEdges().forEach(edge -> {
+			EObject src = (EObject) match.get(edge.getSourceNode().getName());
+			EObject trg = (EObject) match.get(edge.getTargetNode().getName());
+			EMFManipulationUtils.createEdge(src, trg, edge.getType());
+		});
 		return Optional.of(match);
-	}
-
-	/**
-	 * Creates an EObject for the given node and adds the element to the match.
-	 * 
-	 * @param node
-	 *            the node to create
-	 * @param match
-	 *            the match
-	 */
-	private void createNode(final IBeXNode node, final IMatch match) {
-		EObject newNode = EcoreUtil.create(node.getType());
-		this.defaultResource.getContents().add(newNode);
-		match.put(node.getName(), newNode);
-	}
-
-	/**
-	 * Creates an EReference for the given edge.
-	 * 
-	 * @param edge
-	 *            the edge to create
-	 * @param match
-	 *            the match
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void createEdge(final IBeXEdge edge, final IMatch match) {
-		EObject src = (EObject) match.get(edge.getSourceNode().getName());
-		EObject trg = (EObject) match.get(edge.getTargetNode().getName());
-
-		EReference reference = edge.getType();
-		if (reference.isMany()) {
-			((EList) src.eGet(reference)).add(trg);
-		} else {
-			src.eSet(reference, trg);
-		}
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
@@ -20,6 +20,12 @@ import IBeXLanguage.IBeXNode;
 public class GraphTransformationCreateInterpreter implements ICreatePatternInterpreter {
 	private Resource resource;
 
+	/**
+	 * Creates a new GraphTransformationCreateInterpreter.
+	 * 
+	 * @param resource
+	 *            the model resource
+	 */
 	public GraphTransformationCreateInterpreter(final Resource resource) {
 		this.resource = resource;
 	}
@@ -27,23 +33,36 @@ public class GraphTransformationCreateInterpreter implements ICreatePatternInter
 	@Override
 	public Optional<IMatch> apply(final IBeXCreatePattern createPattern, final IMatch match) {
 		createPattern.getCreatedNodes().forEach(node -> this.createNode(node, match));
-		//createPattern.getCreatedEdges().forEach(edge -> this.createEdge(edge, match));
+		createPattern.getCreatedEdges().forEach(edge -> this.createEdge(edge, match));
 		return Optional.of(match);
 	}
 
-	private void createNode(IBeXNode node, final IMatch match) {
+	/**
+	 * Creates an EObject for the given node and adds the element to the match.
+	 * 
+	 * @param node
+	 *            the node to create
+	 * @param match
+	 *            the match
+	 */
+	private void createNode(final IBeXNode node, final IMatch match) {
 		EObject newNode = EcoreUtil.create(node.getType());
 		this.resource.getContents().add(newNode);
 		match.put(node.getName(), newNode);
 	}
 
+	/**
+	 * Creates an EReference for the given edge.
+	 * 
+	 * @param edge
+	 *            the edge to create
+	 * @param match
+	 *            the match
+	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void createEdge(IBeXEdge edge, final IMatch match) {
-		System.out.println(edge.getSourceNode().getName() + " : " + match.get(edge.getSourceNode().getName()));
+	private void createEdge(final IBeXEdge edge, final IMatch match) {
 		EObject src = (EObject) match.get(edge.getSourceNode().getName());
-		EObject trg = (EObject) match.get(edge.getSourceNode().getName());
-
-		System.out.println("Create edge " + edge.getType().getName() + " - " + src + " - " + trg);
+		EObject trg = (EObject) match.get(edge.getTargetNode().getName());
 
 		EReference reference = edge.getType();
 		if (reference.isMany()) {

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationCreateInterpreter.java
@@ -18,16 +18,16 @@ import IBeXLanguage.IBeXNode;
  * Interpreter applying creation of elements for graph transformation.
  */
 public class GraphTransformationCreateInterpreter implements ICreatePatternInterpreter {
-	private Resource resource;
+	private Resource defaultResource;
 
 	/**
 	 * Creates a new GraphTransformationCreateInterpreter.
 	 * 
-	 * @param resource
-	 *            the model resource
+	 * @param defaultResource
+	 *            the default resource
 	 */
-	public GraphTransformationCreateInterpreter(final Resource resource) {
-		this.resource = resource;
+	public GraphTransformationCreateInterpreter(final Resource defaultResource) {
+		this.defaultResource = defaultResource;
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public class GraphTransformationCreateInterpreter implements ICreatePatternInter
 	 */
 	private void createNode(final IBeXNode node, final IMatch match) {
 		EObject newNode = EcoreUtil.create(node.getType());
-		this.resource.getContents().add(newNode);
+		this.defaultResource.getContents().add(newNode);
 		match.put(node.getName(), newNode);
 	}
 

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
@@ -7,7 +7,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emoflon.ibex.common.operational.IDeletePatternInterpreter;
 import org.emoflon.ibex.common.operational.IMatch;
-import org.emoflon.ibex.gt.utils.EMFManipulationUtils;
+import org.emoflon.ibex.common.utils.EMFManipulationUtils;
 
 import IBeXLanguage.IBeXDeletePattern;
 

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
@@ -2,17 +2,14 @@ package org.emoflon.ibex.gt.engine;
 
 import java.util.Optional;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emoflon.ibex.common.operational.IDeletePatternInterpreter;
 import org.emoflon.ibex.common.operational.IMatch;
+import org.emoflon.ibex.gt.utils.EMFManipulationUtils;
 
 import IBeXLanguage.IBeXDeletePattern;
-import IBeXLanguage.IBeXEdge;
-import IBeXLanguage.IBeXNode;
 
 /**
  * Interpreter applying deletion of elements for graph transformation.
@@ -32,57 +29,19 @@ public class GraphTransformationDeleteInterpreter implements IDeletePatternInter
 
 	@Override
 	public Optional<IMatch> apply(final IBeXDeletePattern deletePattern, final IMatch match) {
-		deletePattern.getDeletedNodes().forEach(node -> this.deleteNode(node, match));
-		deletePattern.getDeletedEdges().forEach(edge -> this.deleteEdge(edge, match));
+		deletePattern.getDeletedNodes().forEach(node -> {
+			EObject eObject = (EObject) match.get(node.getName());
+			if (EMFManipulationUtils.isDanglingNode(eObject)) {
+				// Move to trash resource.
+				trashResource.getContents().add(EcoreUtil.getRootContainer(eObject));
+			}
+			EcoreUtil.delete(eObject);
+		});
+		deletePattern.getDeletedEdges().forEach(edge -> {
+			EObject src = (EObject) match.get(edge.getSourceNode().getName());
+			EObject trg = (EObject) match.get(edge.getTargetNode().getName());
+			EMFManipulationUtils.deleteEdge(src, trg, edge.getType());
+		});
 		return Optional.of(match);
-	}
-
-	/**
-	 * Deletes the node.
-	 * 
-	 * @param node
-	 *            the node to delete
-	 * @param match
-	 *            the match
-	 */
-	private void deleteNode(final IBeXNode node, final IMatch match) {
-		EObject eObject = (EObject) match.get(node.getName());
-		if (eObject.eResource() == null) { // Is dangling node?
-			// Move to trash resource.
-			trashResource.getContents().add(EcoreUtil.getRootContainer(eObject));
-		}
-		EcoreUtil.delete(eObject);
-	}
-
-	/**
-	 * Deletes the edge.
-	 * 
-	 * @param edge
-	 *            the edge to delete
-	 * @param match
-	 *            the match
-	 */
-	private void deleteEdge(final IBeXEdge edge, final IMatch match) {
-		EObject src = (EObject) match.get(edge.getSourceNode().getName());
-		EObject trg = (EObject) match.get(edge.getTargetNode().getName());
-		deleteEdge(src, trg, edge.getType());
-	}
-
-	// TODO copied code
-	@SuppressWarnings("rawtypes")
-	private static void deleteEdge(EObject src, EObject trg, EReference ref) {
-		if (src.eResource() == null) {
-			return;
-		}
-		if (ref.isMany()) {
-			EList list = ((EList) src.eGet(ref));
-			if (list.contains(trg)) {
-				list.remove(trg);
-			}
-		} else {
-			if (src.eGet(ref) != null) {
-				src.eUnset(ref);
-			}
-		}
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
@@ -2,25 +2,87 @@ package org.emoflon.ibex.gt.engine;
 
 import java.util.Optional;
 
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emoflon.ibex.common.operational.IDeletePatternInterpreter;
 import org.emoflon.ibex.common.operational.IMatch;
 
 import IBeXLanguage.IBeXDeletePattern;
+import IBeXLanguage.IBeXEdge;
+import IBeXLanguage.IBeXNode;
 
 /**
  * Interpreter applying deletion of elements for graph transformation.
  */
 public class GraphTransformationDeleteInterpreter implements IDeletePatternInterpreter {
+	private Resource trashResource;
+
+	/**
+	 * Creates a new GraphTransformationDeleteInterpreter.
+	 * 
+	 * @param trashResource
+	 *            the resource containing trash objects
+	 */
+	public GraphTransformationDeleteInterpreter(final Resource trashResource) {
+		this.trashResource = trashResource;
+	}
 
 	@Override
-	public Optional<IMatch> apply(IBeXDeletePattern deletePattern, IMatch match) {
-		// TODO Auto-generated method stub
-		deletePattern.getDeletedNodes().forEach(node -> {
-			System.out.println("Delete node " + node.getName() + ": " + node.getType().getName());
-		});
-		deletePattern.getDeletedEdges().forEach(edge -> {
-			System.out.println("Delete edge " + edge.getType().getName());
-		});
+	public Optional<IMatch> apply(final IBeXDeletePattern deletePattern, final IMatch match) {
+		deletePattern.getDeletedNodes().forEach(node -> this.deleteNode(node, match));
+		deletePattern.getDeletedEdges().forEach(edge -> this.deleteEdge(edge, match));
 		return Optional.of(match);
+	}
+
+	/**
+	 * Deletes the node.
+	 * 
+	 * @param node
+	 *            the node to delete
+	 * @param match
+	 *            the match
+	 */
+	private void deleteNode(final IBeXNode node, final IMatch match) {
+		EObject eObject = (EObject) match.get(node.getName());
+		if (eObject.eResource() == null) { // Is dangling node?
+			// Move to trash resource.
+			trashResource.getContents().add(EcoreUtil.getRootContainer(eObject));
+		}
+		EcoreUtil.delete(eObject);
+	}
+
+	/**
+	 * Deletes the edge.
+	 * 
+	 * @param edge
+	 *            the edge to delete
+	 * @param match
+	 *            the match
+	 */
+	private void deleteEdge(final IBeXEdge edge, final IMatch match) {
+		EObject src = (EObject) match.get(edge.getSourceNode().getName());
+		EObject trg = (EObject) match.get(edge.getTargetNode().getName());
+		deleteEdge(src, trg, edge.getType());
+	}
+
+	// TODO copied code
+	@SuppressWarnings("rawtypes")
+	private static void deleteEdge(EObject src, EObject trg, EReference ref) {
+		if (src.eResource() == null) {
+			return;
+		}
+		if (ref.isMany()) {
+			EList list = ((EList) src.eGet(ref));
+			if (list.contains(trg)) {
+				list.remove(trg);
+			}
+		} else {
+			if (src.eGet(ref) != null) {
+				src.eUnset(ref);
+			}
+		}
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationDeleteInterpreter.java
@@ -1,0 +1,26 @@
+package org.emoflon.ibex.gt.engine;
+
+import java.util.Optional;
+
+import org.emoflon.ibex.common.operational.IDeletePatternInterpreter;
+import org.emoflon.ibex.common.operational.IMatch;
+
+import IBeXLanguage.IBeXDeletePattern;
+
+/**
+ * Interpreter applying deletion of elements for graph transformation.
+ */
+public class GraphTransformationDeleteInterpreter implements IDeletePatternInterpreter {
+
+	@Override
+	public Optional<IMatch> apply(IBeXDeletePattern deletePattern, IMatch match) {
+		// TODO Auto-generated method stub
+		deletePattern.getDeletedNodes().forEach(node -> {
+			System.out.println("Delete node " + node.getName() + ": " + node.getType().getName());
+		});
+		deletePattern.getDeletedEdges().forEach(edge -> {
+			System.out.println("Delete edge " + edge.getType().getName());
+		});
+		return Optional.of(match);
+	}
+}

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
@@ -17,7 +17,7 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 import org.emoflon.ibex.common.operational.IMatch;
 import org.emoflon.ibex.common.operational.IMatchObserver;
-import org.emoflon.ibex.common.operational.IPatternInterpreter;
+import org.emoflon.ibex.common.operational.IContextPatternInterpreter;
 
 import IBeXLanguage.IBeXLanguagePackage;
 import IBeXLanguage.IBeXPatternSet;
@@ -40,7 +40,7 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 	/**
 	 * The pattern matching engine.
 	 */
-	private IPatternInterpreter engine;
+	private IContextPatternInterpreter engine;
 
 	/**
 	 * The resource set containing the model file.
@@ -81,7 +81,7 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 	 * @param model
 	 *            the resource set containing the model file
 	 */
-	public GraphTransformationInterpreter(final IPatternInterpreter engine, final ResourceSet model) {
+	public GraphTransformationInterpreter(final IContextPatternInterpreter engine, final ResourceSet model) {
 		this.engine = engine;
 		this.model = model;
 	}

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
@@ -367,7 +367,8 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 	}
 
 	/**
-	 * Unsubscribes the notifications for the given pattern and consumer.
+	 * Deletes the subscription of the notifications for the given pattern and
+	 * consumer.
 	 * 
 	 * @param patternName
 	 *            the name of the pattern
@@ -396,7 +397,8 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 	}
 
 	/**
-	 * Unsubscribes the notifications for the given pattern and consumer.
+	 * Deletes the subscription of the notifications for the given pattern and
+	 * consumer.
 	 * 
 	 * @param patternName
 	 *            the name of the pattern
@@ -425,7 +427,7 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 	}
 
 	/**
-	 * Unsubscribes notifications whenever the given match disappears.
+	 * Deletes the subscription of notifications when the given match disappears.
 	 * 
 	 * @param match
 	 *            the match

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
@@ -1,5 +1,6 @@
 package org.emoflon.ibex.gt.engine;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -186,7 +187,7 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 		String patternName = match.getPatternName();
 
 		IMatch originalMatch = new GraphTransformationSimpleMatch(match);
-		
+
 		// Execute deletion.
 		Optional<IMatch> matchAfterDeletion;
 		Optional<IBeXDeletePattern> deletePattern = this.patternSet.getDeletePatterns().stream()
@@ -342,6 +343,19 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 	 */
 	public void updateMatches() {
 		this.contextPatternInterpreter.updateMatches();
+	}
+
+	/**
+	 * Saves the model.
+	 */
+	public void save() {
+		this.model.getResources().forEach(r -> {
+			try {
+				r.save(null);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		});
 	}
 
 	@Override

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationSimpleMatch.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationSimpleMatch.java
@@ -20,7 +20,7 @@ public class GraphTransformationSimpleMatch implements IMatch {
 	private HashMap<String, Object> parameters = new HashMap<String, Object>();
 
 	/**
-	 * Initializes a match with the given pattern name.
+	 * Initializes an empty match with the given pattern name.
 	 * 
 	 * @param patternName
 	 *            the name of the pattern

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationSimpleMatch.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationSimpleMatch.java
@@ -1,0 +1,67 @@
+package org.emoflon.ibex.gt.engine;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+import org.emoflon.ibex.common.operational.IMatch;
+
+/**
+ * A simple implementation of {@link IMatch}.
+ */
+public class GraphTransformationSimpleMatch implements IMatch {
+	/**
+	 * The name of the pattern.
+	 */
+	private String patternName;
+
+	/**
+	 * The mapping between parameter names and objects.
+	 */
+	private HashMap<String, Object> parameters = new HashMap<String, Object>();
+
+	/**
+	 * Initializes a match with the given pattern name.
+	 * 
+	 * @param patternName
+	 *            the name of the pattern
+	 */
+	public GraphTransformationSimpleMatch(final String patternName) {
+		this.patternName = patternName;
+	}
+
+	/**
+	 * Initializes the match as a copy of the given match.
+	 * 
+	 * @param match
+	 *            the match to copy
+	 */
+	public GraphTransformationSimpleMatch(final IMatch match) {
+		this.patternName = match.getPatternName();
+		match.getParameterNames().forEach(parameterName -> {
+			this.parameters.put(parameterName, match.get(parameterName));
+		});
+	}
+
+	@Override
+	public Object get(final String name) {
+		if (!this.parameters.containsKey(name)) {
+			throw new IllegalArgumentException(String.format("No parameter %s.", name));
+		}
+		return this.parameters.get(name);
+	}
+
+	@Override
+	public Collection<String> getParameterNames() {
+		return this.parameters.keySet();
+	}
+
+	@Override
+	public String getPatternName() {
+		return this.patternName;
+	}
+
+	@Override
+	public void put(final String name, final Object object) {
+		this.parameters.put(name, object);
+	}
+}

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/AbstractModelTransformation.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/AbstractModelTransformation.java
@@ -28,7 +28,7 @@ abstract public class AbstractModelTransformation<SourceModel, TargetModel> {
 	 * Transforms the source into the target model.
 	 * 
 	 * @param sourceModel
-	 *            the source model
+	 *            the source model, must not be <code>null</code>
 	 * @return the target model
 	 */
 	abstract public TargetModel transform(final SourceModel sourceModel);

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/EditorToInternalGTModelTransformation.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/EditorToInternalGTModelTransformation.java
@@ -6,11 +6,17 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.emoflon.ibex.gt.editor.gT.ContextNode;
+import org.emoflon.ibex.gt.editor.gT.ContextReference;
 import org.emoflon.ibex.gt.editor.gT.GraphTransformationFile;
 import org.emoflon.ibex.gt.editor.gT.Node;
+import org.emoflon.ibex.gt.editor.gT.Operator;
+import org.emoflon.ibex.gt.editor.gT.OperatorNode;
+import org.emoflon.ibex.gt.editor.gT.OperatorReference;
 import org.emoflon.ibex.gt.editor.gT.Reference;
 import org.emoflon.ibex.gt.editor.gT.Rule;
 
+import GTLanguage.GTBindingType;
 import GTLanguage.GTEdge;
 import GTLanguage.GTGraph;
 import GTLanguage.GTLanguageFactory;
@@ -82,6 +88,18 @@ public class EditorToInternalGTModelTransformation
 		gtNode.setName(editorNode.getName());
 		gtNode.setType(editorNode.getType());
 		gtNode.setLocal(editorNode.getName().startsWith("_"));
+		if (editorNode instanceof ContextNode) {
+			gtNode.setBindingType(GTBindingType.CONTEXT);
+		} else {
+			if (editorNode instanceof OperatorNode) {
+				OperatorNode editorOperatorNode = (OperatorNode) editorNode;
+				if (editorOperatorNode.getOperator().equals(Operator.CREATE)) {
+					gtNode.setBindingType(GTBindingType.CREATE);
+				} else {
+					gtNode.setBindingType(GTBindingType.DELETE);
+				}
+			}
+		}
 		return gtNode;
 	}
 
@@ -117,6 +135,18 @@ public class EditorToInternalGTModelTransformation
 				GTEdge gtEdge = GTLanguageFactory.eINSTANCE.createGTEdge();
 				gtEdge.setType(reference.getType());
 				gtEdge.setName(sourceNodeName + "-" + gtEdge.getType().getName() + "-" + targetNodeName);
+				if (reference instanceof ContextReference) {
+					gtEdge.setBindingType(GTBindingType.CONTEXT);
+				} else {
+					if (reference instanceof OperatorReference) {
+						OperatorReference editorOperatorReference = (OperatorReference) reference;
+						if (editorOperatorReference.getOperator().equals(Operator.CREATE)) {
+							gtEdge.setBindingType(GTBindingType.CREATE);
+						} else {
+							gtEdge.setBindingType(GTBindingType.DELETE);
+						}
+					}
+				}
 				gtSourceNode.ifPresent(node -> gtEdge.setSourceNode(node));
 				gtTargetNode.ifPresent(node -> gtEdge.setTargetNode(node));
 

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/EditorToInternalGTModelTransformation.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/EditorToInternalGTModelTransformation.java
@@ -40,9 +40,7 @@ public class EditorToInternalGTModelTransformation
 	public GTRuleSet transform(final GraphTransformationFile editorModel) {
 		Objects.requireNonNull(editorModel, "The editor model must not be null!");
 		this.gtRules = new ArrayList<GTRule>();
-		editorModel.getRules().stream() //
-				.filter(r -> !r.isAbstract()) // ignore abstract rules
-				.forEach(editorRule -> this.transformRule(editorRule));
+		editorModel.getRules().forEach(editorRule -> this.transformRule(editorRule));
 
 		GTRuleSet gtRuleSet = GTLanguageFactory.eINSTANCE.createGTRuleSet();
 		gtRuleSet.getRules().addAll(gtRules.stream() //
@@ -71,8 +69,26 @@ public class EditorToInternalGTModelTransformation
 
 		GTRule gtRule = GTLanguageFactory.eINSTANCE.createGTRule();
 		gtRule.setName(editorRule.getName());
+		gtRule.setAbstract(editorRule.isAbstract());
+		gtRule.setExecutable(hasOperatorOrReference(editorRule));
 		gtRule.setGraph(gtGraph);
 		this.gtRules.add(gtRule);
+	}
+
+	/**
+	 * Checks whether the editor rule contains at least one operator node or
+	 * reference.
+	 * 
+	 * @param editorRule
+	 *            the editor rule
+	 * @return true if the rule contains an operator node.
+	 */
+	private static boolean hasOperatorOrReference(final Rule editorRule) {
+		boolean hasOperatorNode = editorRule.getNodes().stream() //
+				.anyMatch(node -> node instanceof OperatorNode);
+		return hasOperatorNode || editorRule.getNodes().stream() //
+				.map(node -> node.getConstraints()).flatMap(constraints -> constraints.stream())
+				.anyMatch(constraint -> constraint instanceof OperatorReference);
 	}
 
 	/**

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/InternalGTModelToIBeXPatternTransformation.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/InternalGTModelToIBeXPatternTransformation.java
@@ -1,21 +1,27 @@
 package org.emoflon.ibex.gt.transformations;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 
+import GTLanguage.GTBindingType;
 import GTLanguage.GTEdge;
 import GTLanguage.GTNode;
 import GTLanguage.GTRule;
 import GTLanguage.GTRuleSet;
+import IBeXLanguage.IBeXCreatePattern;
+import IBeXLanguage.IBeXDeletePattern;
 import IBeXLanguage.IBeXEdge;
 import IBeXLanguage.IBeXLanguageFactory;
+import IBeXLanguage.IBeXNamedElement;
 import IBeXLanguage.IBeXNode;
 import IBeXLanguage.IBeXNodePair;
 import IBeXLanguage.IBeXPattern;
@@ -27,7 +33,17 @@ import IBeXLanguage.IBeXPatternSet;
  */
 public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTransformation<GTRuleSet, IBeXPatternSet> {
 	/**
-	 * All IBeXPatterns created during the transformation.
+	 * All IBeXCreatePatterns.
+	 */
+	private List<IBeXCreatePattern> ibexCreatePatterns;
+
+	/**
+	 * All IBeXDeletePatterns.
+	 */
+	private List<IBeXDeletePattern> ibexDeletePatterns;
+
+	/**
+	 * All (black) IBeXPatterns created during the transformation.
 	 */
 	private List<IBeXPattern> ibexPatterns;
 
@@ -38,13 +54,29 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 
 	@Override
 	public IBeXPatternSet transform(final GTRuleSet gtRuleSet) {
-		this.ibexPatterns = new ArrayList<IBeXPattern>();
-		gtRuleSet.getRules().forEach(gtRule -> this.transformRule(gtRule, true));
+		Objects.requireNonNull(gtRuleSet, "Rule set must not be null!");
 
+		// Transform patterns.
+		this.ibexPatterns = new ArrayList<IBeXPattern>();
+		this.ibexCreatePatterns = new ArrayList<IBeXCreatePattern>();
+		this.ibexDeletePatterns = new ArrayList<IBeXDeletePattern>();
+		gtRuleSet.getRules().forEach(gtRule -> {
+			this.transformRule(gtRule, true);
+			this.transformRuleToCreatePattern(gtRule);
+			this.transformRuleToDeletePattern(gtRule);
+		});
+
+		// Sort pattern lists alphabetically.
+		final Comparator<IBeXNamedElement> sortByName = (a, b) -> a.getName().compareTo(b.getName());
+		this.ibexPatterns.sort(sortByName);
+		this.ibexCreatePatterns.sort(sortByName);
+		this.ibexDeletePatterns.sort(sortByName);
+
+		// Create pattern set with alphabetically pattern lists.
 		IBeXPatternSet ibexPatternSet = IBeXLanguageFactory.eINSTANCE.createIBeXPatternSet();
-		ibexPatternSet.getPatterns().addAll(ibexPatterns.stream() //
-				.sorted((p1, p2) -> p1.getName().compareTo(p2.getName())) //
-				.collect(Collectors.toList()));
+		ibexPatternSet.getPatterns().addAll(ibexPatterns);
+		ibexPatternSet.getCreatePatterns().addAll(ibexCreatePatterns);
+		ibexPatternSet.getDeletePatterns().addAll(ibexDeletePatterns);
 		return ibexPatternSet;
 	}
 
@@ -52,9 +84,10 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 	 * Add the given pattern to the list.
 	 * 
 	 * @param ibexPattern
-	 *            the IBeXPattern to add
+	 *            the IBeXPattern to add, must not be <code>null</code>
 	 */
 	private void addPattern(final IBeXPattern ibexPattern) {
+		Objects.requireNonNull(ibexPattern, "Pattern must not be null!");
 		this.ibexPatterns.add(ibexPattern);
 		this.nameToIBeXPattern.put(ibexPattern.getName(), ibexPattern);
 	}
@@ -75,16 +108,15 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 		IBeXPattern ibexPattern = IBeXLanguageFactory.eINSTANCE.createIBeXPattern();
 		ibexPattern.setName(gtRule.getName());
 
-		gtRule.getGraph().getNodes().stream() //
-				.sorted((n1, n2) -> n1.getName().compareTo(n2.getName())) // alphabetically by name
-				.forEach(gtNode -> {
-					IBeXNode ibexNode = this.transformNode(gtNode);
-					if (gtNode.isLocal()) {
-						ibexPattern.getLocalNodes().add(ibexNode);
-					} else {
-						ibexPattern.getSignatureNodes().add(ibexNode);
-					}
-				});
+		// Transform nodes.
+		filterNodesByBindingTypes(gtRule, GTBindingType.CONTEXT, GTBindingType.DELETE).forEach(gtNode -> {
+			IBeXNode ibexNode = this.transformNode(gtNode);
+			if (gtNode.isLocal()) {
+				ibexPattern.getLocalNodes().add(ibexNode);
+			} else {
+				ibexPattern.getSignatureNodes().add(ibexNode);
+			}
+		});
 
 		// Ensure that all nodes must be disjoint even if they have the same type.
 		List<IBeXNode> allNodes = new ArrayList<IBeXNode>();
@@ -103,20 +135,24 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 			}
 		}
 
+		// Transform edges.
 		if (useInvocations) {
-			gtRule.getGraph().getEdges().stream() //
-					.map(edge -> edge.getType()).distinct() // all types of EReference
+			filterEdgesByBindingTypes(gtRule, GTBindingType.CONTEXT, GTBindingType.DELETE).map(edge -> edge.getType())
+					.distinct() // all types of EReference
 					.sorted((t1, t2) -> t1.getName().compareTo(t2.getName())) // in alphabetical order
 					.forEach(edgeType -> {
 						IBeXPattern edgePattern = this.createEdgePattern(edgeType);
-						Optional<IBeXNode> ibexSignatureSourceNode = findSignatureIBeXNodeWithName(edgePattern, "src");
-						Optional<IBeXNode> ibexSignatureTargetNode = findSignatureIBeXNodeWithName(edgePattern, "trg");
+						Optional<IBeXNode> ibexSignatureSourceNode = findIBeXNodeWithName(
+								edgePattern.getSignatureNodes(), "src");
+						Optional<IBeXNode> ibexSignatureTargetNode = findIBeXNodeWithName(
+								edgePattern.getSignatureNodes(), "trg");
 						if (!ibexSignatureSourceNode.isPresent() || !ibexSignatureTargetNode.isPresent()) {
 							this.logError("Invalid signature nodes for edge pattern!");
 							return;
 						}
 
-						gtRule.getGraph().getEdges().stream().filter(edge -> edgeType.equals(edge.getType()))
+						filterEdgesByBindingTypes(gtRule, GTBindingType.CONTEXT, GTBindingType.DELETE)
+								.filter(edge -> edgeType.equals(edge.getType())) //
 								.forEach(gtEdge -> {
 									IBeXPatternInvocation invocation = IBeXLanguageFactory.eINSTANCE
 											.createIBeXPatternInvocation();
@@ -163,6 +199,8 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 	 * @return the created IBeXPattern
 	 */
 	private IBeXPattern createEdgePattern(final EReference edgeType) {
+		Objects.requireNonNull(edgeType, "Edge type must not be null!");
+
 		String name = "edge-" + edgeType.getEContainingClass().getName() + "-" + edgeType.getName() + "-"
 				+ edgeType.getEReferenceType().getName();
 		if (this.nameToIBeXPattern.containsKey(name)) {
@@ -200,6 +238,7 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 	 * @return the IBeXNode
 	 */
 	private IBeXNode transformNode(final GTNode gtNode) {
+		Objects.requireNonNull(gtNode, "Node must not be null!");
 		IBeXNode ibexNode = IBeXLanguageFactory.eINSTANCE.createIBeXNode();
 		ibexNode.setName(gtNode.getName());
 		ibexNode.setType(gtNode.getType());
@@ -216,12 +255,108 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 	 * @return the IBeXEdge
 	 */
 	private IBeXEdge transformEdge(final GTEdge gtEdge, final IBeXPattern ibexPattern) {
+		Objects.requireNonNull(gtEdge, "Edge must not be null!");
 		IBeXEdge ibexEdge = IBeXLanguageFactory.eINSTANCE.createIBeXEdge();
 		ibexEdge.setType(gtEdge.getType());
 		findIBeXNodeWithName(ibexPattern, gtEdge.getSourceNode().getName())
 				.ifPresent(sourceNode -> ibexEdge.setSourceNode(sourceNode));
 		findIBeXNodeWithName(ibexPattern, gtEdge.getTargetNode().getName())
 				.ifPresent(targetNode -> ibexEdge.setTargetNode(targetNode));
+		return ibexEdge;
+	}
+
+	/**
+	 * Transforms a GTRule into an IBeXPattern for the created parts if there are
+	 * any elements to create.
+	 * 
+	 * @param gtRule
+	 *            the rule, must not be <code>null</code>
+	 */
+	private void transformRuleToCreatePattern(final GTRule gtRule) {
+		Objects.requireNonNull(gtRule, "rule must not be null!");
+		if (hasElementsOfBindingType(gtRule, GTBindingType.CREATE)) {
+			IBeXCreatePattern ibexCreatePattern = IBeXLanguageFactory.eINSTANCE.createIBeXCreatePattern();
+			ibexCreatePattern.setName(gtRule.getName());
+			filterNodesByBindingTypes(gtRule, GTBindingType.CREATE).forEach(gtNode -> {
+				ibexCreatePattern.getCreatedNodes().add(this.transformNode(gtNode));
+			});
+			filterEdgesByBindingTypes(gtRule, GTBindingType.CREATE).forEach(gtEdge -> {
+				IBeXEdge ibexEdge = this.transformEdge(gtEdge, ibexCreatePattern.getCreatedNodes(),
+						ibexCreatePattern.getContextNodes());
+				ibexCreatePattern.getCreatedEdges().add(ibexEdge);
+			});
+			this.ibexCreatePatterns.add(ibexCreatePattern);
+		}
+	}
+
+	/**
+	 * Transforms a GTRule into an IBeXPattern for the deleted parts if there are
+	 * any elements to delete.
+	 * 
+	 * @param gtRule
+	 *            the rule, must not be <code>null</code>
+	 */
+	private void transformRuleToDeletePattern(final GTRule gtRule) {
+		Objects.requireNonNull(gtRule, "rule must not be null!");
+		if (hasElementsOfBindingType(gtRule, GTBindingType.DELETE)) {
+			IBeXDeletePattern ibexDeletePattern = IBeXLanguageFactory.eINSTANCE.createIBeXDeletePattern();
+			ibexDeletePattern.setName(gtRule.getName());
+			filterNodesByBindingTypes(gtRule, GTBindingType.DELETE).forEach(gtNode -> {
+				ibexDeletePattern.getDeletedNodes().add(this.transformNode(gtNode));
+			});
+			filterEdgesByBindingTypes(gtRule, GTBindingType.DELETE).forEach(gtEdge -> {
+				IBeXEdge ibexEdge = this.transformEdge(gtEdge, ibexDeletePattern.getDeletedNodes(),
+						ibexDeletePattern.getContextNodes());
+				ibexDeletePattern.getDeletedEdges().add(ibexEdge);
+			});
+			this.ibexDeletePatterns.add(ibexDeletePattern);
+		}
+	}
+
+	/**
+	 * Transforms the given edge into an {@link IBeXEdge}. If a source or target
+	 * node does not exist in the lists of changed or context nodes, the node will
+	 * be added to the context nodes.
+	 * 
+	 * @param gtEdge
+	 *            the edge
+	 * @param changedNodes
+	 *            the list of nodes
+	 * @param contextNodes
+	 *            the list of nodes where
+	 * @return the transformed edge
+	 */
+	private IBeXEdge transformEdge(final GTEdge gtEdge, final List<IBeXNode> changedNodes,
+			final List<IBeXNode> contextNodes) {
+		Objects.requireNonNull(gtEdge, "Edge must not be null!");
+		Objects.requireNonNull(gtEdge.getSourceNode(), "Edge must have a source node!");
+		Objects.requireNonNull(gtEdge.getTargetNode(), "Edge must have a source node!");
+		Objects.requireNonNull(changedNodes, "Changed node must not be null!");
+		Objects.requireNonNull(contextNodes, "Context node must not be null!");
+
+		IBeXEdge ibexEdge = IBeXLanguageFactory.eINSTANCE.createIBeXEdge();
+		ibexEdge.setType(gtEdge.getType());
+
+		Optional<IBeXNode> ibexSourceNode = findIBeXNodeWithName(changedNodes, contextNodes,
+				gtEdge.getSourceNode().getName());
+		if (ibexSourceNode.isPresent()) {
+			ibexEdge.setSourceNode(ibexSourceNode.get());
+		} else {
+			IBeXNode node = this.transformNode(gtEdge.getSourceNode());
+			contextNodes.add(node);
+			ibexEdge.setSourceNode(node);
+		}
+
+		Optional<IBeXNode> ibexTargetNode = findIBeXNodeWithName(changedNodes, contextNodes,
+				gtEdge.getTargetNode().getName());
+		if (ibexTargetNode.isPresent()) {
+			ibexEdge.setTargetNode(ibexTargetNode.get());
+		} else {
+			IBeXNode node = this.transformNode(gtEdge.getTargetNode());
+			contextNodes.add(node);
+			ibexEdge.setTargetNode(node);
+		}
+
 		return ibexEdge;
 	}
 
@@ -236,8 +371,48 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 	 * @return true if and only if an object could be an instance of both classes
 	 */
 	private static boolean canInstancesBeTheSame(final EClass class1, final EClass class2) {
+		Objects.requireNonNull(class1);
+		Objects.requireNonNull(class2);
 		return class1.getName().equals(class2.getName()) || class1.getEAllSuperTypes().contains(class2)
 				|| class2.getEAllSuperTypes().contains(class1);
+	}
+
+	/**
+	 * Searches for an {@link IBeXNode} with the given name in the given list of
+	 * nodes.
+	 * 
+	 * @param nodes
+	 *            the nodes
+	 * @param name
+	 *            the name to search for
+	 * @return an {@link Optional} for a node with the given name
+	 */
+	private static Optional<IBeXNode> findIBeXNodeWithName(final List<IBeXNode> nodes, final String name) {
+		Objects.requireNonNull(nodes, "nodes must not be null!");
+		Objects.requireNonNull(name, "name must not be null!");
+		return nodes.stream().filter(node -> name.equals(node.getName())).findAny();
+	}
+
+	/**
+	 * Searches for an {@link IBeXNode} with the given name in the given lists of
+	 * nodes.
+	 * 
+	 * @param nodes
+	 *            the nodes
+	 * @param nodes2
+	 *            more nodes
+	 * @param name
+	 *            the name to search for
+	 * @return an {@link Optional} for a node with the given name
+	 */
+	private static Optional<IBeXNode> findIBeXNodeWithName(final List<IBeXNode> nodes, final List<IBeXNode> nodes2,
+			final String name) {
+		Optional<IBeXNode> node = findIBeXNodeWithName(nodes, name);
+		if (node.isPresent()) {
+			return node;
+		} else {
+			return findIBeXNodeWithName(nodes2, name);
+		}
 	}
 
 	/**
@@ -249,30 +424,74 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 	 *            the name to search for, must not be <code>null</code>
 	 * @return an Optional for a local IBeXNode
 	 */
-	public static Optional<IBeXNode> findIBeXNodeWithName(final IBeXPattern ibexPattern, final String name) {
+	private static Optional<IBeXNode> findIBeXNodeWithName(final IBeXPattern ibexPattern, final String name) {
 		Objects.requireNonNull(ibexPattern, "pattern must not be null!");
 		Objects.requireNonNull(name, "name must not be null!");
-		Optional<IBeXNode> node = ibexPattern.getLocalNodes().stream().filter(n -> name.equals(n.getName())).findAny();
-		if (node.isPresent()) {
-			return node;
-		} else {
-			return findSignatureIBeXNodeWithName(ibexPattern, name);
-		}
+		return findIBeXNodeWithName(ibexPattern.getLocalNodes(), ibexPattern.getSignatureNodes(), name);
 	}
 
 	/**
-	 * Finds an {@link IBeXNode} with the given name in the signature nodes of the
-	 * given IBeXPattern.
+	 * Checks whether the graph of the rule contains nodes or edges of the given
+	 * binding type.
 	 * 
-	 * @param ibexPattern
-	 *            the IBeXPattern, must not be <code>null</code>
-	 * @param name
-	 *            the name to search for, must not be <code>null</code>
-	 * @return an Optional for a signature IBeXNode
+	 * @param gtRule
+	 *            the rule
+	 * @param bindingType
+	 *            the binding type
+	 * @return <code>true</code> if and only if the graph contains at least one node
+	 *         or edge of the binding type
 	 */
-	private static Optional<IBeXNode> findSignatureIBeXNodeWithName(final IBeXPattern ibexPattern, final String name) {
-		Objects.requireNonNull(ibexPattern, "pattern must not be null!");
-		Objects.requireNonNull(name, "name must not be null!");
-		return ibexPattern.getSignatureNodes().stream().filter(n -> name.equals(n.getName())).findAny();
+	private static boolean hasElementsOfBindingType(final GTRule gtRule, final GTBindingType bindingType) {
+		Objects.requireNonNull(gtRule, "Rule must not be null!");
+		return gtRule.getGraph().getNodes().stream().anyMatch(node -> node.getBindingType().equals(bindingType))
+				|| gtRule.getGraph().getEdges().stream().anyMatch(node -> node.getBindingType().equals(bindingType));
+	}
+
+	/**
+	 * Filters the nodes of the rule for the ones with the given binding type.
+	 * 
+	 * @param gtRule
+	 *            the rule
+	 * @param bindingType
+	 *            the binding type
+	 * @return the stream of nodes, sorted alphabetically by the name
+	 */
+	private static Stream<GTNode> filterNodesByBindingTypes(final GTRule gtRule, final GTBindingType... bindingTypes) {
+		Objects.requireNonNull(gtRule, "Rule must not be null!");
+		List<GTBindingType> bindingTypesList = validateBindingTypes(bindingTypes);
+		return gtRule.getGraph().getNodes().stream()
+				.filter(gtNode -> bindingTypesList.contains(gtNode.getBindingType()))
+				.sorted((a, b) -> a.getName().compareTo(b.getName()));
+	}
+
+	/**
+	 * Filters the edges of the rule for the ones with the given binding type.
+	 * 
+	 * @param gtRule
+	 *            the rule
+	 * @param bindingTypes
+	 *            the binding types
+	 * @return the stream of edges, sorted alphabetically by the name
+	 */
+	private static Stream<GTEdge> filterEdgesByBindingTypes(final GTRule gtRule, final GTBindingType... bindingTypes) {
+		Objects.requireNonNull(gtRule, "Rule must not be null!");
+		List<GTBindingType> bindingTypesList = validateBindingTypes(bindingTypes);
+		return gtRule.getGraph().getEdges().stream()
+				.filter(gtEdge -> bindingTypesList.contains(gtEdge.getBindingType()))
+				.sorted((a, b) -> a.getName().compareTo(b.getName()));
+	}
+
+	/**
+	 * Check that the array of bindingTypes contains at lest one element.
+	 * 
+	 * @param bindingTypes
+	 *            the array of binding types
+	 * @return the list of binding types
+	 */
+	private static List<GTBindingType> validateBindingTypes(final GTBindingType... bindingTypes) {
+		if (bindingTypes.length < 1) {
+			throw new IllegalArgumentException("At least one binding type required!");
+		}
+		return Arrays.asList(bindingTypes);
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/InternalGTModelToIBeXPatternTransformation.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/transformations/InternalGTModelToIBeXPatternTransformation.java
@@ -118,6 +118,11 @@ public class InternalGTModelToIBeXPatternTransformation extends AbstractModelTra
 			}
 		});
 
+		// Abort if there are no nodes, i. e. everything is created.
+		if (ibexPattern.getLocalNodes().isEmpty() && ibexPattern.getSignatureNodes().isEmpty()) {
+			return;
+		}
+
 		// Ensure that all nodes must be disjoint even if they have the same type.
 		List<IBeXNode> allNodes = new ArrayList<IBeXNode>();
 		allNodes.addAll(ibexPattern.getLocalNodes());

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/utils/EMFManipulationUtils.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/utils/EMFManipulationUtils.java
@@ -1,0 +1,68 @@
+package org.emoflon.ibex.gt.utils;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+
+/**
+ * Utility methods for manipulating EMF models.
+ */
+public class EMFManipulationUtils {
+
+	/**
+	 * Checks whether the given object is a dangling node.
+	 * 
+	 * @param eObject
+	 *            the node
+	 * @return true if the node is a dangling node
+	 */
+	public static boolean isDanglingNode(final EObject eObject) {
+		return eObject.eResource() == null;
+	}
+
+	/**
+	 * Creates a reference between the two objects
+	 * 
+	 * @param source
+	 *            the source node
+	 * @param target
+	 *            the target node
+	 * @param reference
+	 *            the edge type
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static void createEdge(final EObject source, final EObject target, final EReference reference) {
+		if (reference.isMany()) {
+			((EList) source.eGet(reference)).add(target);
+		} else {
+			source.eSet(reference, target);
+		}
+	}
+
+	/**
+	 * Delete the given EReference between the two objects.
+	 * 
+	 * @param source
+	 *            the source node
+	 * @param target
+	 *            the target node
+	 * @param reference
+	 *            the edge type
+	 */
+	@SuppressWarnings("rawtypes")
+	public static void deleteEdge(final EObject source, final EObject target, final EReference reference) {
+		if (source.eResource() == null) {
+			return;
+		}
+		if (reference.isMany()) {
+			EList list = ((EList) source.eGet(reference));
+			if (list.contains(target)) {
+				list.remove(target);
+			}
+		} else {
+			if (source.eGet(reference) != null) {
+				source.eUnset(reference);
+			}
+		}
+	}
+}

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/IBlackInterpreter.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/IBlackInterpreter.java
@@ -1,12 +1,12 @@
 package org.emoflon.ibex.tgg.operational;
 
-import org.emoflon.ibex.common.operational.IPatternInterpreter;
+import org.emoflon.ibex.common.operational.IContextPatternInterpreter;
 import org.emoflon.ibex.tgg.operational.defaults.IbexOptions;
 
 /**
  * Interface for bidirectional graph transformations via TGGs
  */
-public interface IBlackInterpreter extends IPatternInterpreter {
+public interface IBlackInterpreter extends IContextPatternInterpreter {
 	/**
 	 * Sets the IBeXOptions.
 	 * 

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/defaults/IbexGreenInterpreter.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/defaults/IbexGreenInterpreter.java
@@ -6,12 +6,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.emoflon.ibex.common.utils.EMFManipulationUtils;
 import org.emoflon.ibex.tgg.compiler.patterns.common.IbexBasePattern;
 import org.emoflon.ibex.tgg.operational.IGreenInterpreter;
 import org.emoflon.ibex.tgg.operational.csp.IRuntimeTGGAttrConstrContainer;
@@ -51,7 +50,9 @@ public class IbexGreenInterpreter implements IGreenInterpreter {
 		for (TGGRuleEdge e : greenEdges) {
 			EObject src = (EObject) comatch.get(e.getSrcNode().getName());
 			EObject trg = (EObject) comatch.get(e.getTrgNode().getName());
-			if(createEMFEdge) createEMFEdge(e, src, trg);
+			if (createEMFEdge) {
+				EMFManipulationUtils.createEdge(src, trg, e.getType());
+			}
 			result.add(new RuntimeEdge(src, trg, e.getType()));
 		}
 		
@@ -64,15 +65,6 @@ public class IbexGreenInterpreter implements IGreenInterpreter {
 		for (TGGRuleCorr c : greenCorrs) {
 			comatch.put(c.getName(), createCorr(comatch, c, comatch.get(c.getSource().getName()), comatch.get(c.getTarget().getName()), corrR));
 		}
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private void createEMFEdge(TGGRuleEdge e, EObject src, EObject trg) {
-		EReference ref = e.getType();
-		if (ref.isMany())
-			((EList) src.eGet(ref)).add(trg);
-		else
-			src.eSet(ref, trg);
 	}
 
 	private EObject createNode(IMatch match, TGGRuleNode node, Resource resource) {


### PR DESCRIPTION
# Added
- Transformation to `IBeXCreatePattern`s and `IBeXDeletePattern`s.
- `IBeXPattern` for the context may be empty if everything is created by the rule. Pattern matchers have to deal with this.
- If the context pattern for a rule is empty, `findMatches()` will return one empty match indicating that the rule is applicable.
- `apply()` and `apply(M match)` is available for rules which have at least one `++` or `--` element (node or reference).
- Calling `apply()` will execute the rule on a match by finding an arbitrary match, delete the elements included in the `IBeXDeletePattern` and create the elements included in the `IBeXCreatePattern` for the rule.

# Refactoring
- Extract `EMFManipulationUtils` with utility for manipulating EMF models. These methods are shared for GT and TGG.