### PR TITLE
Extend API with methods using the incrementality for rules

### DIFF
--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
@@ -26,7 +26,7 @@ public abstract class GraphTransformationAPI {
 	/**
 	 * The pushout approach to use if no approach is specified.
 	 */
-	protected PushoutApproach defaultPushout = PushoutApproach.SPO;
+	protected PushoutApproach defaultPushoutApproach = PushoutApproach.SPO;
 
 	/**
 	 * Creates a new GraphTransformationAPI for given engine and resource set.
@@ -74,11 +74,11 @@ public abstract class GraphTransformationAPI {
 	/**
 	 * Changes the default pushout approach.
 	 * 
-	 * @param defaultPushout
+	 * @param defaultPushoutApproach
 	 *            the pushout approach to set
 	 */
-	public void setDefaultPushout(final PushoutApproach defaultPushout) {
-		this.defaultPushout = defaultPushout;
+	public void setDefaultPushoutApproach(final PushoutApproach defaultPushoutApproach) {
+		this.defaultPushoutApproach = defaultPushoutApproach;
 	}
 
 	/**
@@ -86,7 +86,7 @@ public abstract class GraphTransformationAPI {
 	 * 
 	 * @return the default pushout approach
 	 */
-	public PushoutApproach getDefaultPushout() {
-		return this.defaultPushout;
+	public PushoutApproach getDefaultPushoutApproach() {
+		return this.defaultPushoutApproach;
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationAPI.java
@@ -16,6 +16,9 @@ import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
  * All elements created during rule applications are added to the default
  * resource. The default resource can be explicitly set in the constructor,
  * otherwise the first resource in the resource set will be used.
+ * 
+ * Per default, all rule applications use the single pushout approach. This
+ * behavior can be changed for the whole API or for single rules.
  */
 public abstract class GraphTransformationAPI {
 	/**
@@ -67,18 +70,32 @@ public abstract class GraphTransformationAPI {
 	/**
 	 * Triggers an incremental update of the matches.
 	 */
-	public void updateMatches() {
+	public final void updateMatches() {
 		this.interpreter.updateMatches();
 	}
 
 	/**
-	 * Changes the default pushout approach.
+	 * Sets the default pushout approach.
 	 * 
 	 * @param defaultPushoutApproach
 	 *            the pushout approach to set
 	 */
-	public void setDefaultPushoutApproach(final PushoutApproach defaultPushoutApproach) {
+	public final void setDefaultPushoutApproach(final PushoutApproach defaultPushoutApproach) {
 		this.defaultPushoutApproach = defaultPushoutApproach;
+	}
+
+	/**
+	 * Sets the pushout approach to double pushout.
+	 */
+	public final void setDPO() {
+		this.setDefaultPushoutApproach(PushoutApproach.DPO);
+	}
+
+	/**
+	 * Sets the pushout approach to single pushout.
+	 */
+	public final void setSPO() {
+		this.setDefaultPushoutApproach(PushoutApproach.SPO);
 	}
 
 	/**
@@ -86,7 +103,7 @@ public abstract class GraphTransformationAPI {
 	 * 
 	 * @return the default pushout approach
 	 */
-	public PushoutApproach getDefaultPushoutApproach() {
+	public final PushoutApproach getDefaultPushoutApproach() {
 		return this.defaultPushoutApproach;
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationApplicableRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationApplicableRule.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -29,6 +30,7 @@ import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
  */
 public abstract class GraphTransformationApplicableRule<M extends GraphTransformationMatch<M, R>, R extends GraphTransformationRule<M, R>>
 		extends GraphTransformationRule<M, R> {
+	private Consumer<M> autoApply = m -> this.apply(m);
 
 	/**
 	 * Creates a new executable rule.
@@ -196,5 +198,22 @@ public abstract class GraphTransformationApplicableRule<M extends GraphTransform
 			match = matchSupplier.get();
 		}
 		return matches;
+	}
+
+	/**
+	 * Applies the rule automatically whenever a match is found.
+	 * 
+	 * Note: This will not work for rules which are contain only created elements as
+	 * the rule is always applicable in this case.
+	 */
+	public final void applyWheneverApplicable() {
+		this.subscribeAppearing(autoApply);
+	}
+
+	/**
+	 * Stops automatic rule application whenever a match is found.
+	 */
+	public final void applyWheneverApplicableStop() {
+		this.unsubscribeAppearing(autoApply);
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationApplicableRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationApplicableRule.java
@@ -1,16 +1,26 @@
 package org.emoflon.ibex.gt.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 
+import org.emoflon.ibex.common.operational.IMatch;
 import org.emoflon.ibex.common.operational.PushoutApproach;
 import org.emoflon.ibex.gt.engine.GraphTransformationInterpreter;
 
 /**
- * This is the abstraction for all applicable rules.
+ * This is the abstraction for all applicable rules. Via <code>apply()</code>
+ * and its variants, rules can be applied.
  * 
- * Concrete Implementations must have a constructor to set the parameters
- * required for rule application and getters for all parameters.
+ * If no pushout approach is explicitly defined when calling a
+ * <code>apply</code> method, the default pushout approach of the API which
+ * created the rule will be used.
+ * 
+ * Concrete Implementations of this class should provide typed methods for
+ * binding the parameters.
  * 
  * @param <M>
  *            the type of matches returned by this rule
@@ -36,31 +46,31 @@ public abstract class GraphTransformationApplicableRule<M extends GraphTransform
 	}
 
 	/**
-	 * Applies the rule on an arbitrary match with SPO semantics if a match can be
-	 * found.
+	 * Applies the rule on an arbitrary match with the default pushout approach if a
+	 * match can be found.
 	 * 
 	 * @return an {@link Optional} for the the match after rule application
 	 */
 	public final Optional<M> apply() {
-		return this.apply(this.api.getDefaultPushout());
+		return this.apply(this.api.getDefaultPushoutApproach());
 	}
 
 	/**
-	 * Applies the rule on the given match with SPO semantics.
+	 * Applies the rule on the given match using the default pushout approach.
 	 * 
 	 * @param match
 	 *            the match
 	 * @return an {@link Optional} for the the match after rule application
 	 */
 	public final Optional<M> apply(final M match) {
-		return this.apply(match, this.api.getDefaultPushout());
+		return this.apply(match, this.api.getDefaultPushoutApproach());
 	}
 
 	/**
-	 * Applies the rule on the given match with the given pushout semantics.
+	 * Applies the rule on the given match using the given pushout approach.
 	 * 
 	 * @param po
-	 *            the pushout semantics
+	 *            the pushout approach to use
 	 * @return an {@link Optional} for the the match after rule application
 	 */
 	public final Optional<M> apply(final PushoutApproach po) {
@@ -72,12 +82,12 @@ public abstract class GraphTransformationApplicableRule<M extends GraphTransform
 	}
 
 	/**
-	 * Applies the rule on the given match with the given pushout semantics.
+	 * Applies the rule on the given match using the given pushout approach.
 	 * 
 	 * @param match
 	 *            the match
 	 * @param po
-	 *            the pushout semantics
+	 *            the pushout approach to use
 	 * @return an {@link Optional} for the the match after rule application
 	 */
 	public final Optional<M> apply(final M match, final PushoutApproach po) {
@@ -85,4 +95,106 @@ public abstract class GraphTransformationApplicableRule<M extends GraphTransform
 		return this.interpreter.apply(match.toIMatch(), po).map(m -> this.convertMatch(m));
 	}
 
+	/**
+	 * Applies the rule on at most <code>max</code> arbitrary matches using the
+	 * default pushout approach.
+	 * 
+	 * @param max
+	 *            the maximal number of rule applications
+	 * @return the matches after rule application
+	 */
+	public final Collection<M> apply(final int max) {
+		return this.apply(max, this.api.getDefaultPushoutApproach());
+	}
+
+	/**
+	 * Applies the rule on at most <code>max</code> arbitrary matches using the
+	 * given pushout approach.
+	 * 
+	 * @param count
+	 *            the maximal number of rule applications
+	 * @param po
+	 *            the pushout approach to use
+	 * @return the matches after rule application
+	 */
+	public final Collection<M> apply(final int count, final PushoutApproach po) {
+		return this.apply(matches -> matches.size() < count && this.hasMatches());
+	}
+
+	/**
+	 * Applies the rule as long as the given condition is fulfilled using the
+	 * default pushout approach.
+	 * 
+	 * @param condition
+	 *            the condition to check, based on the matches of rule applications
+	 *            so far
+	 * @return the matches after rule application
+	 */
+	public final Collection<M> apply(final Predicate<Collection<M>> condition) {
+		return this.apply(condition, this.api.getDefaultPushoutApproach());
+	}
+
+	/**
+	 * Applies the rule as long as the given condition is fulfilled using the given
+	 * pushout approach.
+	 * 
+	 * @param condition
+	 *            the condition to check, based on the matches of rule applications
+	 *            so far
+	 * @param po
+	 *            the pushout approach to use
+	 * @return the matches after rule application
+	 */
+	public final Collection<M> apply(final Predicate<Collection<M>> condition, final PushoutApproach po) {
+		Collection<M> matches = new ArrayList<M>();
+		while (condition.test(matches)) {
+			this.apply(po).ifPresent(m -> matches.add(m));
+		}
+		return matches;
+	}
+
+	/**
+	 * Applies the rule after binding its parameters to the values given by the
+	 * match.
+	 * 
+	 * @param match
+	 *            the match
+	 * @return the match after rule application
+	 */
+	public final Optional<M> bindAndApply(final IMatch match) {
+		this.bind(match);
+		return this.apply();
+	}
+
+	/**
+	 * Applies the rule after binding its parameters to the values given by the
+	 * match.
+	 * 
+	 * @param match
+	 *            the match
+	 * @return the match after rule application
+	 */
+	public final Optional<M> bindAndApply(final GraphTransformationMatch<?, ?> match) {
+		this.bind(match);
+		return this.apply();
+	}
+
+	/**
+	 * Applies the rule after binding its parameters to the values given by the
+	 * match the supplier returns as long as the the match is not <code>null</code>.
+	 * 
+	 * @param matchSupplier
+	 *            the supplier for a match whose bindings shall be used
+	 * @return the matches after rule application
+	 */
+	public final Collection<M> bindAndApply(final Supplier<? extends GraphTransformationMatch<?, ?>> matchSupplier) {
+		Collection<M> matches = new ArrayList<M>();
+		GraphTransformationMatch<?, ?> match = matchSupplier.get();
+		while (match != null) {
+			this.bind(match);
+			this.apply().ifPresent(m -> matches.add(m));
+			match = matchSupplier.get();
+		}
+		return matches;
+	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationMatch.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationMatch.java
@@ -7,14 +7,11 @@ import org.emoflon.ibex.common.operational.IMatch;
  * 
  * Concrete implementations must have typed getters and setters for all nodes in
  * the rule which are not fixed by a parameter in the rule application.
- * 
- * @author Patrick Robrecht
- * @version 0.1
  *
  * @param <M>
  *            the own type
  * @param <R>
- *            the type of the rule application the match is for
+ *            the type of the rule the match is for
  */
 public abstract class GraphTransformationMatch<M extends GraphTransformationMatch<M, R>, R extends GraphTransformationRule<M, R>> {
 	/**
@@ -31,7 +28,7 @@ public abstract class GraphTransformationMatch<M extends GraphTransformationMatc
 	 * Creates a new Match for the given rule application.
 	 * 
 	 * @param rule
-	 *            the rule application
+	 *            the rule
 	 * @param match
 	 *            the untyped match
 	 */
@@ -41,11 +38,11 @@ public abstract class GraphTransformationMatch<M extends GraphTransformationMatc
 	}
 
 	/**
-	 * Returns the rule application the match is for.
+	 * Returns the rule the match is for.
 	 * 
-	 * @return the rule application the match is for
+	 * @return the rule the match is for
 	 */
-	public R getRule() {
+	public final R getRule() {
 		return this.rule;
 	}
 
@@ -54,7 +51,7 @@ public abstract class GraphTransformationMatch<M extends GraphTransformationMatc
 	 * 
 	 * @return the untyped match
 	 */
-	public IMatch toIMatch() {
+	public final IMatch toIMatch() {
 		return this.match;
 	}
 }

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
@@ -67,15 +67,6 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	}
 
 	/**
-	 * Returns the name of the rule.
-	 * 
-	 * @return the rule name
-	 */
-	protected final String getRuleName() {
-		return this.ruleName;
-	}
-
-	/**
 	 * Returns the parameters.
 	 * 
 	 * @return the parameters

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
@@ -172,17 +172,17 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	}
 
 	/**
-	 * Deletes the subscription of notifications of all new matches for the given
+	 * Removes the subscription of notifications of all new matches for the given
 	 * {@link Consumer}.
 	 * 
 	 * @param action
-	 *            the {@link Consumer}
+	 *            the {@link Consumer} to remove
 	 */
 	public final void unsubscribeAppearing(final Consumer<M> action) {
 		if (this.consumers.containsKey(action)) {
 			this.interpreter.unsubscibeAppearing(this.ruleName, this.consumers.get(action));
 		} else {
-			throw new IllegalArgumentException("Cannot remove a consumer which was not registered before");
+			throw new IllegalArgumentException("Cannot remove a consumer which was not registered before!");
 		}
 	}
 
@@ -197,17 +197,17 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	}
 
 	/**
-	 * Deletes the subscription of notifications of all disappearing matches for the
+	 * Removes the subscription of notifications of all disappearing matches for the
 	 * given {@link Consumer}.
 	 * 
 	 * @param action
-	 *            the {@link Consumer}
+	 *            the {@link Consumer} to remove
 	 */
 	public final void unsubscribeDisappearing(final Consumer<M> action) {
 		if (this.consumers.containsKey(action)) {
 			this.interpreter.unsubscibeDisappearing(this.ruleName, this.consumers.get(action));
 		} else {
-			throw new IllegalArgumentException("Cannot remove a consumer which was not registered before");
+			throw new IllegalArgumentException("Cannot remove a consumer which was not registered before!");
 		}
 	}
 
@@ -224,15 +224,19 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	}
 
 	/**
-	 * Deletes the subscription of a notification when the given match disappears.
+	 * Removes the subscription of a notification when the given match disappears.
 	 * 
 	 * @param match
 	 *            the match to observe
 	 * @param action
-	 *            the {@link Consumer} to notify
+	 *            the {@link Consumer} to remove
 	 */
 	public final void unsubscribeMatchDisappears(final M match, final Consumer<M> action) {
-		this.interpreter.unsubscribeMatchDisappears(match.toIMatch(), this.convertConsumer(action));
+		if (this.consumers.containsKey(action)) {
+			this.interpreter.unsubscribeMatchDisappears(match.toIMatch(), this.convertConsumer(action));
+		} else {
+			throw new IllegalArgumentException("Cannot remove a consumer which was not registered before!");
+		}
 	}
 
 	/**

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationRule.java
@@ -116,8 +116,7 @@ public abstract class GraphTransformationRule<M extends GraphTransformationMatch
 	 *            the match
 	 */
 	@SuppressWarnings("unchecked")
-	public final <Mx extends GraphTransformationMatch<Mx, Rx>, Rx extends GraphTransformationRule<Mx, Rx>> R bind(
-			final GraphTransformationMatch<Mx, Rx> match) {
+	public final R bind(final GraphTransformationMatch<?, ?> match) {
 		this.bind(match.toIMatch());
 		return (R) this;
 	}

--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/engine/GraphTransformationInterpreter.java
@@ -299,6 +299,9 @@ public class GraphTransformationInterpreter implements IMatchObserver {
 			matchAfterCreation = matchAfterDeletion;
 		}
 
+		// Rule application may invalidate existing or lead to new matches.
+		this.updateMatches();
+
 		// Return the co-match.
 		return matchAfterCreation;
 	}


### PR DESCRIPTION
- Apply a rule immediately as soon as it becomes applicable: `enableAutoApply()` (can be deactivated via `disableAutoApply()`.
- Apply a rule multiple times: `apply(final int max)` or based on a condition:` apply(final Predicate<Collection<M>> condition)`
- `setDPO()` and `setSPO()` for API and rules.
- Combine `bind` and `apply` to a new method `bindAndApply`. Via `bindAndApply(final Supplier<? extends GraphTransformationMatch<?, ?>> matchSupplier)` one can calculate the match whose parameters are bound to the rule parameters on demand.
- Add subscriptions for rule applications.

Tests: https://github.com/eMoflon/emoflon-ibex-tests/pull/54