### PR TITLE
GT: Order for deletion

### DIFF
--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFEdge.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFEdge.java
@@ -1,0 +1,76 @@
+package org.emoflon.ibex.common.utils;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+
+/**
+ * A representation for an edge in a EMF model.
+ */
+public class EMFEdge {
+	private final EObject source;
+	private final EObject target;
+	private final EReference type;
+
+	/**
+	 * Creates an edge.
+	 * 
+	 * @param source
+	 *            the source object
+	 * @param target
+	 *            the target object
+	 * @param type
+	 *            the edge type
+	 */
+	public EMFEdge(final EObject source, final EObject target, final EReference type) {
+		this.source = source;
+		this.target = target;
+		this.type = type;
+	}
+
+	/**
+	 * Returns the source.
+	 * 
+	 * @return the source object
+	 */
+	public EObject getSource() {
+		return source;
+	}
+
+	/**
+	 * Returns the target
+	 * 
+	 * @return the target object
+	 */
+	public EObject getTarget() {
+		return target;
+	}
+
+	/**
+	 * Returns the edge type.
+	 * 
+	 * @return the edge type
+	 */
+	public EReference getType() {
+		return type;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (o instanceof EMFEdge) {
+			EMFEdge e = (EMFEdge) o;
+			return getSource().equals(e.getSource()) && getTarget().equals(e.getTarget())
+					&& getType().equals(e.getType());
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return 17 * source.hashCode() + 31 * target.hashCode() + type.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return source.toString() + " -- " + type.getName() + " -> " + target.toString();
+	}
+}

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFManipulationUtils.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFManipulationUtils.java
@@ -1,10 +1,13 @@
 package org.emoflon.ibex.common.utils;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 
 /**
  * Utility methods for manipulating EMF models.
@@ -77,6 +80,38 @@ public class EMFManipulationUtils {
 			if (source.eGet(reference) != null) {
 				source.eUnset(reference);
 			}
+		}
+	}
+
+	/**
+	 * Removes the given nodes and edges in the following order:
+	 * <ol>
+	 * <li>the regular edges</li>
+	 * <li>the nodes</li>
+	 * <li>the containment edges</li>
+	 * </ol>
+	 * 
+	 * @param nodesToDelete
+	 *            the nodes marked for deletion
+	 * @param edgesToDelete
+	 *            the edges marked for deletion
+	 * @param trashResource
+	 *            the resource resource whether dangling nodes are moved to
+	 */
+	public static void delete(final Set<EObject> nodesToDelete, final Set<EMFEdge> edgesToDelete,
+			final Resource trashResource) {
+		// Delete nodes.
+		for (EObject node : nodesToDelete) {
+			if (EMFManipulationUtils.isDanglingNode(node)) {
+				// Move to trash resource.
+				trashResource.getContents().add(EcoreUtil.getRootContainer(node));
+			}
+			EcoreUtil.delete(node);
+		}
+
+		// Delete edges.
+		for (EMFEdge edge : edgesToDelete) {
+			EMFManipulationUtils.deleteEdge(edge.getSource(), edge.getTarget(), edge.getType());
 		}
 	}
 }

--- a/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFManipulationUtils.java
+++ b/org.emoflon.ibex.common/src/org/emoflon/ibex/common/utils/EMFManipulationUtils.java
@@ -84,7 +84,7 @@ public class EMFManipulationUtils {
 	}
 
 	/**
-	 * Removes the given nodes and edges in the following order:
+	 * Deletes the given nodes and edges in the following order:
 	 * <ol>
 	 * <li>the regular edges</li>
 	 * <li>the nodes</li>
@@ -100,18 +100,42 @@ public class EMFManipulationUtils {
 	 */
 	public static void delete(final Set<EObject> nodesToDelete, final Set<EMFEdge> edgesToDelete,
 			final Resource trashResource) {
-		// Delete nodes.
+		deleteEdges(edgesToDelete, false);
+		deleteNodes(nodesToDelete, trashResource);
+		deleteEdges(edgesToDelete, true);
+	}
+
+	/**
+	 * Deletes the given nodes.
+	 * 
+	 * @param nodesToDelete
+	 *            the nodes marked for deletion
+	 * @param trashResource
+	 *            the resource resource whether dangling nodes are moved to
+	 */
+	private static void deleteNodes(final Set<EObject> nodesToDelete, final Resource trashResource) {
 		for (EObject node : nodesToDelete) {
-			if (EMFManipulationUtils.isDanglingNode(node)) {
-				// Move to trash resource.
+			if (isDanglingNode(node)) {
+				// Move node to trash resource.
 				trashResource.getContents().add(EcoreUtil.getRootContainer(node));
 			}
 			EcoreUtil.delete(node);
 		}
+	}
 
-		// Delete edges.
+	/**
+	 * Deletes the edges whose type has the containment set to the given value.
+	 * 
+	 * @param edgesToDelete
+	 *            the edges marked for deletion
+	 * @param containment
+	 *            the containment setting
+	 */
+	private static void deleteEdges(final Set<EMFEdge> edgesToDelete, boolean containment) {
 		for (EMFEdge edge : edgesToDelete) {
-			EMFManipulationUtils.deleteEdge(edge.getSource(), edge.getTarget(), edge.getType());
+			if (edge.getType().isContainment() == containment) {
+				deleteEdge(edge.getSource(), edge.getTarget(), edge.getType());
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR aims to fix https://github.com/eMoflon/emoflon-ibex-democles/issues/64 regarding the order of deletion.

- Add deletion utils considering the order to `EMFManipulationUtils`.
- Adjust the deletion interpreter for GT to use this utils.

The branch `deletion-error` in https://github.com/mde-lab-sessions/running-example-for-lecture contains the example mentioned in the issue. The test case will fail with ibex master, but run succesfully with this deletion-order branch.

The class `RuntimeEdge` in the TGG part can be replaced with `EMFEdge` from the common package.
