### PR TITLE
Fix 4 src trg injectivity ignore

### DIFF
--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/compiler/transformations/patterns/common/OperationalPatternTransformation.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/compiler/transformations/patterns/common/OperationalPatternTransformation.java
@@ -78,7 +78,7 @@ public abstract class OperationalPatternTransformation {
 				if(ruleNode_i.getBindingType() != ruleNode_j.getBindingType())
 					continue;
 				
-				if(options.ignoreSrcTrgInjectivity() && !ruleNode_i.getDomainType().equals(ruleNode_j.getDomainType()))
+				if(options.ignoreInjectivity().test(ruleNode_i, ruleNode_j))
 					continue;
 				
 				if (IBeXPatternOptimiser.unequalConstraintNecessary(ruleNode_i, ruleNode_j)) {

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/compiler/transformations/patterns/common/OperationalPatternTransformation.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/compiler/transformations/patterns/common/OperationalPatternTransformation.java
@@ -75,7 +75,10 @@ public abstract class OperationalPatternTransformation {
 			for (int j = i + 1; j < allNodes.size(); j++) {
 				TGGRuleNode ruleNode_i = allNodes.get(i);
 				TGGRuleNode ruleNode_j = allNodes.get(j);
-				if(options.ignoreSrcTrgInjectivity() || ruleNode_i.getBindingType() != ruleNode_j.getBindingType())
+				if(ruleNode_i.getBindingType() != ruleNode_j.getBindingType())
+					continue;
+				
+				if(options.ignoreSrcTrgInjectivity() && !ruleNode_i.getDomainType().equals(ruleNode_j.getDomainType()))
 					continue;
 				
 				if (IBeXPatternOptimiser.unequalConstraintNecessary(ruleNode_i, ruleNode_j)) {

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/defaults/IbexOptions.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/defaults/IbexOptions.java
@@ -1,6 +1,8 @@
 package org.emoflon.ibex.tgg.operational.defaults;
 
 import java.util.Collection;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 import org.apache.log4j.Level;
@@ -13,6 +15,7 @@ import org.emoflon.ibex.tgg.util.ilp.ILPFactory.SupportedILPSolver;
 
 import language.TGG;
 import language.TGGRule;
+import language.TGGRuleNode;
 
 public class IbexOptions {
 	private boolean blackInterpSupportsAttrConstrs = true;
@@ -28,10 +31,10 @@ public class IbexOptions {
 	private boolean repairAttributes;
 	private EPackage corrMetamodel;
 	private FilterNACStrategy lookAheadStrategy;
-	private boolean ignoreSrcTrgInjecitity;
+	private BiPredicate<TGGRuleNode, TGGRuleNode> ignoreInjecitity;
+	private boolean ignoreDomainConformity;
 	private boolean useShortcutRules;
 	private boolean optimizeSyncPattern;
-	
 
 	/**
 	 * Switch to using edge patterns based on some heuristics (e.g., pattern size).
@@ -48,7 +51,8 @@ public class IbexOptions {
 		setIlpSolver(SupportedILPSolver.Sat4J);
 		useEdgePatterns = false;
 		lookAheadStrategy = FilterNACStrategy.FILTER_NACS;
-		ignoreSrcTrgInjecitity = false;
+		ignoreInjecitity = (x,y) -> false;
+		ignoreDomainConformity = false;
 		optimizeSyncPattern = false;
 	}
 
@@ -215,12 +219,21 @@ public class IbexOptions {
 		return this;
 	}
 
-	public boolean ignoreSrcTrgInjectivity() {
-		return ignoreSrcTrgInjecitity;
+	public BiPredicate<TGGRuleNode, TGGRuleNode> ignoreInjectivity() {
+		return ignoreInjecitity;
 	}
 	
-	public IbexOptions ignoreSrcTrgInjectivity(boolean ignoreSrcTrgInjecitity) {
-		this.ignoreSrcTrgInjecitity = ignoreSrcTrgInjecitity;
+	public IbexOptions ignoreInjectivity(BiPredicate<TGGRuleNode, TGGRuleNode> ignoreInjecitity) {
+		this.ignoreInjecitity = ignoreInjecitity;
+		return this;
+	}
+
+	public boolean ignoreDomainConformity() {
+		return ignoreDomainConformity;
+	}
+	
+	public IbexOptions ignoreDomainConformity(boolean ignoreDomainConformity) {
+		this.ignoreDomainConformity = ignoreDomainConformity;
 		return this;
 	}
 }

--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/OperationalStrategy.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/strategies/OperationalStrategy.java
@@ -258,7 +258,7 @@ public abstract class OperationalStrategy implements IMatchObserver {
 	}
 	
 	private boolean matchIsDomainConform(IMatch match) {
-		if (domainsHaveNoSharedTypes || options.ignoreSrcTrgInjectivity())
+		if (domainsHaveNoSharedTypes || options.ignoreDomainConformity())
 			return true;
 
 		return matchedNodesAreInCorrectResource(s, //


### PR DESCRIPTION
Domain Conformity is now toggle via IbexOptions
Injectivity Constraints can now be filtered using a BiPredicate also via IbexOptions