### PR TITLE
Added missing handling of constraint attributes of type BasicEList

### DIFF
--- a/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/csp/RuntimeTGGAttributeConstraintContainer.java
+++ b/org.emoflon.ibex.tgg.core.runtime/src/org/emoflon/ibex/tgg/operational/csp/RuntimeTGGAttributeConstraintContainer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EDataType;
@@ -177,6 +178,9 @@ public class RuntimeTGGAttributeConstraintContainer implements IRuntimeTGGAttrCo
 				return Integer.parseInt((String) o);
 			else if (o instanceof String && type.getInstanceClass().equals(double.class))
 				return Double.parseDouble((String) o);
+			else if (o instanceof BasicEList)
+				// Shallow copy
+				return ((BasicEList<?>) o).clone();
 			else if (o instanceof Collection)
 				// Currently no handling for collections
 				return o;


### PR DESCRIPTION
Contraint attributes of type BasicEList were handled as Collections, where the BasicEList itself was returned to apply the new attribute value, causing the BasicEList to get cleared (due to the standard eSet implementation). Hence a handling of BasicEList was added, where a shallow copy of it is returned.  