### PR TITLE
Incompatibility with `Xtext v2.33.0` and `MWE2 v2.16.0`: Fixes broken dependencies

### DIFF
--- a/org.emoflon.ibex.gt.statemodel/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.gt.statemodel/META-INF/MANIFEST.MF
@@ -16,5 +16,8 @@ Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.core.runtime,
  org.emoflon.ibex.common,
  org.apache.commons.logging,
- org.eclipse.emf.mwe2.launch
+ org.eclipse.emf.mwe2.launch,
+ org.eclipse.emf.mwe2.lib,
+ org.eclipse.emf.codegen,
+ org.eclipse.emf.codegen.ecore
 Bundle-ActivationPolicy: lazy

--- a/org.emoflon.ibex.gt.statemodel/build.properties
+++ b/org.emoflon.ibex.gt.statemodel/build.properties
@@ -9,5 +9,4 @@ jars.compile.order = .
 source.. = src-gen/,\
            src/
 output.. = bin/
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.generator
+additional.bundles = org.eclipse.xtext.xbase

--- a/org.emoflon.ibex.patternmodel/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.patternmodel/META-INF/MANIFEST.MF
@@ -15,5 +15,8 @@ Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.core.runtime,
  org.eclipse.emf.mwe2.launch,
  org.apache.log4j,
- org.apache.commons.logging
+ org.apache.commons.logging,
+ org.eclipse.emf.mwe2.lib,
+ org.eclipse.emf.codegen,
+ org.eclipse.emf.codegen.ecore
 Bundle-ActivationPolicy: lazy

--- a/org.emoflon.ibex.patternmodel/build.properties
+++ b/org.emoflon.ibex.patternmodel/build.properties
@@ -9,5 +9,4 @@ jars.compile.order = .
 source.. = src-gen/,\
 		   src/
 output.. = bin/
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.generator
+additional.bundles = org.eclipse.xtext.xbase

--- a/org.emoflon.ibex.tgg.core.language/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.tgg.core.language/META-INF/MANIFEST.MF
@@ -25,7 +25,10 @@ Require-Bundle: com.google.guava,
  org.eclipse.xtext,
  org.moflon.core.plugins,
  org.eclipse.emf.mwe2.launch,
- org.apache.commons.logging
+ org.apache.commons.logging,
+ org.eclipse.emf.mwe2.lib,
+ org.eclipse.emf.codegen,
+ org.eclipse.emf.codegen.ecore
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: eMoflon::IBeX Developers
 Bundle-ManifestVersion: 2

--- a/org.emoflon.ibex.tgg.core.language/build.properties
+++ b/org.emoflon.ibex.tgg.core.language/build.properties
@@ -15,5 +15,4 @@ bin.includes = META-INF/,\
 source.. = src/,\
            gen/, \
            xtend-gen/
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.generator
+additional.bundles = org.eclipse.xtext.xbase

--- a/org.emoflon.ibex.tgg.core.runtime/META-INF/MANIFEST.MF
+++ b/org.emoflon.ibex.tgg.core.runtime/META-INF/MANIFEST.MF
@@ -27,7 +27,10 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.emoflon.smartemf,
  org.moflon.core.propertycontainer;bundle-version="2.1.0",
  org.eclipse.emf.mwe2.launch,
- org.apache.commons.logging
+ org.apache.commons.logging,
+ org.eclipse.emf.mwe2.lib,
+ org.eclipse.emf.codegen,
+ org.eclipse.emf.codegen.ecore
 Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: lib/commons-io-2.5.jar,

--- a/org.emoflon.ibex.tgg.core.runtime/build.properties
+++ b/org.emoflon.ibex.tgg.core.runtime/build.properties
@@ -21,5 +21,4 @@ bin.includes = META-INF/,\
 source.. = src/,\
            gen/
 jars.compile.order = .
-additional.bundles = org.eclipse.xtext.xbase,\
-                     org.eclipse.xtext.generator
+additional.bundles = org.eclipse.xtext.xbase


### PR DESCRIPTION
This PR helps towards closing https://github.com/eMoflon/emoflon-ibex/issues/420.