### PR TITLE
GT: `JavaFileGenerator`: add `synchronized` keyword to all generated rule + pattern access methods

### DIFF
--- a/org.emoflon.ibex.gt/xtend-src/org/emoflon/ibex/gt/codegen/JavaFileGenerator.xtend
+++ b/org.emoflon.ibex.gt/xtend-src/org/emoflon/ibex/gt/codegen/JavaFileGenerator.xtend
@@ -201,7 +201,7 @@ class JavaFileGenerator {
 						*
 						* @return the new instance of the rule»
 						*/
-						public «getRuleClassName(rule)» «rule.name»(«FOR parameter : rule.parameters SEPARATOR ', '»final «getJavaType(parameter.type)» «parameter.name»Value«ENDFOR») {
+						public synchronized «getRuleClassName(rule)» «rule.name»(«FOR parameter : rule.parameters SEPARATOR ', '»final «getJavaType(parameter.type)» «parameter.name»Value«ENDFOR») {
 							try{
 								«getRuleClassName(rule)» rule = («getRuleClassName(rule)») interpreter.getRegisteredGraphTransformationPattern("«rule.name»");
 								«FOR parameter : rule.parameters»
@@ -212,7 +212,7 @@ class JavaFileGenerator {
 								return new «getRuleClassName(rule)»(this, interpreter«FOR parameter : rule.parameters BEFORE ', 'SEPARATOR ', '»«parameter.name»Value«ENDFOR»);
 							}
 						}
-			«ENDFOR»
+				«ENDFOR»
 				«FOR pattern : ibexModel.patternSet.contextPatterns
 						.filter [ pattern | !rulePreconditions.contains(pattern)]
 						.filter [ pattern | !pattern.name.contains("CONDITION")]»
@@ -222,7 +222,7 @@ class JavaFileGenerator {
 						*
 						* @return the new instance of the pattern»
 						*/
-						public «getPatternClassName(pattern)» «pattern.name»(«FOR parameter : getPatternParameter(pattern) SEPARATOR ', '»final «getJavaType(parameter.type)» «parameter.name»Value«ENDFOR») {
+						public synchronized «getPatternClassName(pattern)» «pattern.name»(«FOR parameter : getPatternParameter(pattern) SEPARATOR ', '»final «getJavaType(parameter.type)» «parameter.name»Value«ENDFOR») {
 							try{
 								«getPatternClassName(pattern)» pattern = («getPatternClassName(pattern)») interpreter.getRegisteredGraphTransformationPattern("«pattern.name»");
 								«FOR parameter : getPatternParameter(pattern)»


### PR DESCRIPTION
This ensures that eMoflon::IBeX can be used in parallel environments, i.e., where the calls to the same generated getter for a specific pattern or rule may happen concurrently.

This will close https://github.com/Echtzeitsysteme/gips/issues/303.