### PR TITLE
GT patterns: `findMatches` synchronized

### DIFF
--- a/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationPattern.java
+++ b/org.emoflon.ibex.gt/src/org/emoflon/ibex/gt/api/GraphTransformationPattern.java
@@ -1,6 +1,8 @@
 package org.emoflon.ibex.gt.api;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -172,7 +174,7 @@ public abstract class GraphTransformationPattern<M extends GraphTransformationMa
 	 * 
 	 * @return the list of matches (can be empty if no matches exist)
 	 */
-	public final Collection<M> findMatches(boolean doUpdate) {
+	public final synchronized Collection<M> findMatches(boolean doUpdate) {		
 		return matchStream(doUpdate).collect(Collectors.toSet());
 	}
 	
@@ -181,7 +183,7 @@ public abstract class GraphTransformationPattern<M extends GraphTransformationMa
 	 * 
 	 * @return the list of matches (can be empty if no matches exist)
 	 */
-	public final Collection<M> findMatches() {
+	public final synchronized Collection<M> findMatches() {
 		return matchStream(true).collect(Collectors.toSet());
 	}
 	


### PR DESCRIPTION
This fixes a bug where eMoflon::IBeX(-GT) could throw a `ConcurrentModificationException` when querying for new matches in parallel.